### PR TITLE
🔧 [Chore/#07] PR 담당자 및 리뷰어 자동 지정 설정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Lseojeong @chae1125

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,23 @@
+name: Auto assign pull request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR author
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addAssignees({
+              ...context.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #7 

## ✅ 체크 사항

- [ ] UI 동작 및 레이아웃 확인 (해당 없음)
- [x] 콘솔 로그 및 에러 없음
- [ ] 기능 정상 동작 (병합 후 신규 PR 생성으로 확인 예정)
- [x] 팀 컨벤션 확인

## 📝 작업 내용

- PR 생성 시 작성자를 담당자로 자동 지정하는 GitHub Actions 워크플로우를 추가했습니다.
- `CODEOWNERS`를 설정해 FE 팀원이 자동으로 리뷰어로 지정되도록 구성했습니다.
- FE 코드 오너로 `Lseojeong`, `chae1125`를 등록했습니다.

### 📸 스크린샷

### 📦 추가한 라이브러리

### 💬 리뷰 요구사항

- PR이 병합되고 나서 잘 되는지 확인해볼 수 있을 거 같습니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 새로 생성된 PR이 자동으로 작성자에게 할당됩니다.

* **기타**
  * 코드 소유자 검토 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->