### PR TITLE
🔧 [Chore/#04] 경로 alias 설정

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path alias */
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     /* Linting */
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- 관련: #4 (alias 부분만 우선 진행, 프로젝트 폴더 구조는 별도 작업 예정이라 이슈는 닫지 않음)

## ✅ 체크 사항

- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인
- [ ] UI 동작 및 레이아웃 확인 (해당 없음 — 설정 파일만 변경)
- [ ] 콘솔 로그 및 에러 없음 (해당 없음 — 설정 파일만 변경)

## 📝 작업 내용

- TypeScript 경로 alias `@/` 설정 (`tsconfig.app.json`의 `compilerOptions.paths`에 `"@/*": ["./src/*"]` 추가, `baseUrl`은 TS 6에서 deprecated라 제외)
- Vite 경로 alias `@/` 설정 (`vite.config.ts`의 `resolve.alias`에 `@` → `./src` 매핑 추가)

### 📸 스크린샷

- 해당 없음

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 프로젝트 폴더 구조(pages/features/components 등)는 이번 PR에 포함하지 않았고, 내일 별도 PR로 진행 예정입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프로젝트 내 `src` 경로를 `@` 별칭으로 참조할 수 있도록 설정했습니다.
  * TypeScript와 Vite 환경에서 경로 별칭이 일관되게 인식됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->