### PR TITLE
🔧 [Chore/#18] 컨벤션, 아키텍처, CLAUDE.md 문서 작성

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+Claude Code가 이 저장소에서 작업할 때 참고하는 컨텍스트입니다.
+
+## Project Overview
+
+React + Vite + TypeScript 기반 프론트엔드. 네이티브 앱(iOS/Android) 빌드는 Capacitor / React Native 둘 중 미정.
+
+## Commands
+
+```bash
+pnpm dev       # 개발 서버
+pnpm build     # tsc -b && vite build
+pnpm lint      # eslint
+pnpm test      # jest
+pnpm preview   # 빌드 결과 미리보기
+```
+
+- 패키지 매니저는 **pnpm만** 사용한다. `package-lock.json`/`yarn.lock`을 생성하지 말 것.
+
+## Tech Stack
+
+React + Vite, TypeScript.
+서버 상태 TanStack Query, 전역 상태 Zustand, 폼 React Hook Form + Zod, HTTP Axios, 스타일 Tailwind + CVA.
+
+> Zustand / RHF / Zod의 실제 적용 범위, **네이티브 래퍼(Capacitor vs React Native)**는 아직 미확정. 확정된 것처럼 가정하지 말 것.
+
+## Architecture & Code Style
+
+- 디렉토리 구조, 의존 방향(`app → pages → features → shared`), 상태관리 규칙: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- 네이밍, Import(`@/` alias), Props/Type, TSDoc, 주석 규칙: [docs/CONVENTIONS.md](docs/CONVENTIONS.md)
+- 인증/토큰 처리는 `src/shared/apis`에서만. feature별 `apis`는 공통 인스턴스만 가져다 쓴다.
+
+## Git
+
+- 브랜치: `타입/기능명-이슈번호` (예: `feat/login-ui-10`), `develop`에서 생성해서 `develop`으로 PR.
+- 커밋: `깃모지 Type: 작업 내용` (예: `✨ Feat: 로그인 기능 추가`), 한글, 마침표 없음.
+- Squash merge, 승인 후 merge, merge 후 브랜치 삭제.
+- 전체 규칙: [docs/GITFLOW.md](docs/GITFLOW.md)
+
+## Testing
+
+- Jest + React Testing Library. 설정은 `jest.config.cjs`, 셋업은 `src/setupTests.ts`.
+- 테스트 파일은 대상 파일과 같은 폴더에 `ComponentName.test.tsx`로 둔다.
+- `render()`가 던지는 에러는 Jest가 알아서 실패 처리하므로 `expect(() => render(...)).not.toThrow()` 같은 래핑은 하지 않는다.
+
+## Gotchas
+
+- `tsconfig.app.json`은 Vite 번들러 전용 옵션(`moduleResolution: bundler`)을 쓰기 때문에 Jest가 그대로 못 읽는다. `jest.config.cjs` 안에 별도 inline tsconfig를 두고 있다.
+- `docs/GITFLOW.md`, `AGENTS.md`는 아직 작성 전이다 (다른 팀원 담당).
+- 앱 배포 방식, CI/CD, 환경변수 관리 전략은 미확정. 관련 작업 전에 먼저 확인할 것.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,7 +70,7 @@
 
 ## 3. Directory Structure
 
-```
+```text
 src/
 ├── app/                # 앱 진입점, 전역 설정
 │   ├── providers/
@@ -98,7 +98,7 @@ src/
 
 ### Feature 내부 구조 (기본형)
 
-```
+```text
 features/receipt/
 ├── components/
 ├── hooks/
@@ -130,7 +130,7 @@ features/receipt/
 
 ### Feature 내부 구조 (화면이 여러 개인 경우)
 
-```
+```text
 features/report/
 ├── components/
 │   ├── common/     # feature 안에서 2곳 이상 쓰는 것
@@ -170,7 +170,7 @@ features/report/
 
 ## 5. Dependency Direction
 
-```
+```text
 app → pages → features → shared
 ```
 
@@ -198,9 +198,9 @@ app → pages → features → shared
 
 ## 7. Form & Validation
 
-> 세부 적용 범위는 와이어프레임 확인 후 결정
+> 적용 범위는 와이어프레임 확인 후 결정 — 그 전까지는 아래 규칙을 확정된 것으로 간주하지 않는다
 
-- React Hook Form + Zod 사용
+- 폼 적용이 확정되면 React Hook Form + Zod 사용
 - 단순 입력은 Local State 사용
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,280 @@
+# 프론트엔드 기술 스택 및 프로젝트 구조
+
+## 1. Tech Stack
+
+### Core
+
+| 구분 | 기술 |
+| --- | --- |
+| Framework | React, Vite |
+| Language | TypeScript |
+| Package Manager | pnpm |
+| UI Documentation | Storybook |
+
+### State & Data
+
+| 구분 | 기술 |
+| --- | --- |
+| Server State | TanStack Query |
+| Client State | Zustand |
+| Form | React Hook Form |
+| Validation | Zod |
+| HTTP Client | Axios |
+
+> Zustand, React Hook Form, Zod는 와이어프레임 확인 후 사용 범위 확정
+
+### Styling
+
+| 구분 | 기술 |
+| --- | --- |
+| CSS | Tailwind CSS |
+| Component Variant | CVA |
+
+### Code Quality
+
+- ESLint
+- Prettier
+- Husky
+- CodeRabbit
+
+### Native & External
+
+| 기능 | 기술 |
+| --- | --- |
+| 지도 | 네이버 지도 |
+
+> React Native WebView와 Capacitor 중 PoC 비교 후 결정 (약 1주)
+> 카메라, 푸시 알림 구현 방식은 래핑 방식 확정 후 결정
+> 웹 앱 코드(React + Vite + TS)는 어느 쪽으로 가도 그대로 사용
+
+---
+
+## 2. Architecture Rule
+
+### 공통화 기준
+
+- 사용처가 2곳 이상일 때 공통 영역으로 분리
+- 하나의 기능에서만 사용하면 해당 Feature 내부에서 관리
+- 공통 Type, Constant가 아니라면 Feature 내부에서 관리
+
+### 파일 분리 기준
+
+- 파일 수가 적으면 하나의 파일에서 관리
+- 파일 수가 많아지면 역할별 폴더로 확장
+- 과도한 폴더 분리 지양
+- 관련 코드는 최대한 가까운 위치에서 관리
+
+> `index.ts` 규칙은 [CONVENTIONS.md](./CONVENTIONS.md) 7번 참고
+
+---
+
+## 3. Directory Structure
+
+```
+src/
+├── app/                # 앱 진입점, 전역 설정
+│   ├── providers/
+│   ├── routes/
+│   ├── styles/
+│   └── App.tsx
+├── pages/              # 라우트 단위 화면, feature 조합만 담당
+├── features/           # 도메인 단위 기능
+└── shared/             # 도메인에 종속되지 않는 공통 코드
+    ├── ui/
+    ├── layout/
+    ├── hooks/
+    ├── stores/         # 2곳 이상에서 사용하는 전역 상태
+    ├── utils/
+    ├── apis/           # axiosInstance, 인터셉터, 공통 에러 핸들링
+    ├── constants/
+    ├── types/
+    ├── assets/
+    └── lib
+```
+
+`pages`, `features` 하위 도메인 이름은 동일하게 맞춘다.
+
+`auth` / `onboarding` / `receipt` / `report` / `map` / `shop` / `mypage` / `notification`
+
+### Feature 내부 구조 (기본형)
+
+```
+features/receipt/
+├── components/
+├── hooks/
+├── stores/         # 해당 도메인 전용 전역 상태
+├── apis/
+│   ├── getReceipts.ts
+│   ├── postReceipt.ts
+│   └── index.ts
+├── queries/
+│   ├── useReceiptListQuery.ts
+│   ├── useReceiptDetailQuery.ts
+│   └── index.ts
+├── mutations/
+│   ├── useCreateReceiptMutation.ts
+│   ├── useDeleteReceiptMutation.ts
+│   └── index.ts
+├── queryKeys.ts
+├── schemas.ts
+├── types.ts        # DTO 타입만
+├── constants.ts
+├── utils/
+└── index.ts
+```
+
+- `queries`, `mutations`는 훅 하나당 파일 하나
+- 파일명은 훅 이름과 동일하게 (`useReceiptListQuery.ts` → `useReceiptListQuery`)
+- 폴더 안 `index.ts`에서 모아서 export
+- 쿼리 키는 `queryKeys.ts`에서 한 곳으로 관리
+
+### Feature 내부 구조 (화면이 여러 개인 경우)
+
+```
+features/report/
+├── components/
+│   ├── common/     # feature 안에서 2곳 이상 쓰는 것
+│   ├── streak/
+│   └── monthly/
+├── hooks/
+│   ├── common/
+│   ├── streak/
+│   └── monthly/
+├── apis/
+├── queries/
+├── mutations/
+├── queryKeys.ts
+├── schemas.ts
+├── types.ts
+├── constants.ts
+├── utils/
+└── index.ts
+```
+
+- 필요한 폴더만 만든다
+- 파일이 적으면 파일 하나로 관리, 많아지면 화면·역할 단위 폴더로 확장
+- 화면 단위로 나눌지는 컴포넌트 개수 보고 판단
+
+---
+
+## 4. Component 위치 기준
+
+| 범위 | 위치 |
+| --- | --- |
+| 전역 공통 UI (Button, Modal 등) | `shared/ui` |
+| 레이아웃 (Header, TabBar 등) | `shared/layout` |
+| 특정 기능 전용 | `features/{feature}/components` |
+| 화면 조합 | `pages/{page}` |
+
+---
+
+## 5. Dependency Direction
+
+```
+app → pages → features → shared
+```
+
+- feature 간 직접 import 금지 (공통으로 올리거나 pages에서 조합)
+- `shared`는 어떤 feature도 import하지 않는다
+- `pages`에는 비즈니스 로직을 두지 않는다
+
+---
+
+## 6. State Management
+
+- 서버 상태: TanStack Query
+- 전역 상태: Zustand
+- 로컬 상태: useState, useReducer
+- Context: Theme 및 Provider 용도
+
+### Store 위치
+
+| 범위 | 위치 |
+| --- | --- |
+| 해당 도메인에서만 사용 | `features/{feature}/stores` |
+| 2곳 이상에서 사용 | `shared/stores` |
+
+---
+
+## 7. Form & Validation
+
+> 세부 적용 범위는 와이어프레임 확인 후 결정
+
+- React Hook Form + Zod 사용
+- 단순 입력은 Local State 사용
+
+---
+
+## 8. API Structure
+
+### 공통 API (`src/shared/apis`)
+
+- Axios 인스턴스 생성 및 설정 (baseURL, timeout 등)
+- 인증 토큰을 포함한 인터셉터(Request/Response Interceptor) 설정
+- 공통 에러 핸들링 로직
+- 여러 Feature에서 공통으로 사용하는 API 함수
+
+### 기능별 API (`src/features/{feature}/apis`)
+
+- 해당 Feature 전용 API 요청 함수
+- `shared/apis`에서 만든 공통 Axios 인스턴스를 가져와서 사용
+- 이 Feature에서만 쓰는 엔드포인트 함수만 위치
+
+### 규칙
+
+- 인증/토큰 처리는 `src/shared/apis`에서만 관리하고, 기능별 `apis`에서 직접 헤더를 설정하지 않는다
+- 기능별 `apis`는 공통 인스턴스를 import해서 엔드포인트 함수만 작성한다
+
+---
+
+## 9. Styling
+
+- Tailwind CSS 사용
+- Variant는 CVA 사용
+
+---
+
+## 10. Package Manager
+
+### pnpm 선택 이유
+
+| 항목 | 내용 |
+| --- | --- |
+| 설치 속도 | 동일 패키지 재사용 |
+| 디스크 효율 | 중복 패키지 최소화 |
+| 호환성 | npm 생태계와 높은 호환성 |
+| 사용성 | npm과 유사한 명령어 |
+| 유지보수 | Yarn Berry보다 낮은 러닝 커브 |
+
+### 비교
+
+| Package Manager | 장점 | 단점 |
+| --- | --- | --- |
+| npm | 기본 내장, 높은 호환성 | 설치 속도 및 디스크 효율 |
+| Yarn Classic | 안정적인 Lockfile | 유지보수 중심 |
+| Yarn Berry | PnP, Zero Install | 설정 복잡도 및 러닝 커브 |
+| pnpm | 속도, 용량, 호환성 | 엄격한 의존성 관리 |
+
+### 사용 규칙
+
+- pnpm으로 통일
+- `pnpm-lock.yaml` Commit
+- `package-lock.json` 생성 금지
+- `yarn.lock` 생성 금지
+- Package Manager 혼용 금지
+
+---
+
+## 11. Pending
+
+- Zustand 적용 범위
+- React Hook Form 적용 범위
+- Zod 적용 범위
+- 앱 래핑 방식 (RN WebView vs Capacitor)
+- 앱 배포 방식
+- 환경 변수 관리
+- CI/CD
+
+---
+
+코드 네이밍 규칙은 [CONVENTIONS.md](./CONVENTIONS.md)를, Git/브랜치/커밋/PR 규칙은 [GITFLOW.md](./GITFLOW.md)를 참고하세요.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,9 +92,7 @@ src/
     └── lib
 ```
 
-`pages`, `features` 하위 도메인 이름은 동일하게 맞춘다.
-
-`auth` / `onboarding` / `receipt` / `report` / `map` / `shop` / `mypage` / `notification`
+`pages`는 라우트 또는 화면 목적을 기준으로 구성하고, `features`는 비즈니스 기능과 도메인을 기준으로 구성한다. 두 계층의 이름은 필요할 때만 동일하게 사용한다.
 
 ### Feature 내부 구조 (기본형)
 
@@ -238,22 +236,7 @@ app → pages → features → shared
 
 ### pnpm 선택 이유
 
-| 항목 | 내용 |
-| --- | --- |
-| 설치 속도 | 동일 패키지 재사용 |
-| 디스크 효율 | 중복 패키지 최소화 |
-| 호환성 | npm 생태계와 높은 호환성 |
-| 사용성 | npm과 유사한 명령어 |
-| 유지보수 | Yarn Berry보다 낮은 러닝 커브 |
-
-### 비교
-
-| Package Manager | 장점 | 단점 |
-| --- | --- | --- |
-| npm | 기본 내장, 높은 호환성 | 설치 속도 및 디스크 효율 |
-| Yarn Classic | 안정적인 Lockfile | 유지보수 중심 |
-| Yarn Berry | PnP, Zero Install | 설정 복잡도 및 러닝 커브 |
-| pnpm | 속도, 용량, 호환성 | 엄격한 의존성 관리 |
+속도·디스크 효율이 좋고 npm 생태계와 호환성이 높으면서도 명령어가 npm과 유사해 러닝 커브가 낮다.
 
 ### 사용 규칙
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -42,6 +42,20 @@
 | 이벤트 함수 | `handle + 동사` | `handleSubmit` |
 | Event Props | `on + 동사` | `onSubmit` |
 
+### 함수 선언 방식
+
+- Page, Component는 선언식 함수로 작성
+- 그 외 함수는 화살표 함수로 작성
+
+```tsx
+// Page, Component
+export default function Page() {}
+
+// 그 외
+const change = () => {};
+export const get = () => {};
+```
+
 ### 이벤트 이름
 
 - 대상이 명확하도록 작성

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,175 @@
+# 프론트엔드 코드 컨벤션
+
+## 1. Naming Convention
+
+### Directory
+
+| 대상 | 규칙 | 예시 |
+| --- | --- | --- |
+| 디렉토리 | `kebab-case` | `user-profile` |
+
+### File
+
+| 대상 | 규칙 | 예시 |
+| --- | --- | --- |
+| Component | `PascalCase` | `ReceiptCard.tsx` |
+| 일반 TypeScript | `camelCase` | `formatDate.ts` |
+| Custom Hook | `use + camelCase` | `useReceipt.ts` |
+| Schema | `camelCase` | `receiptSchema.ts` |
+| Store | `camelCase` | `authStore.ts` |
+| Asset | `kebab-case` | `ic-arrow-left.svg` |
+| Page Component | `PascalCase + Page` | `MainPage.tsx` |
+| Storybook | `컴포넌트명 + .stories` | `ReceiptCard.stories.tsx` |
+
+- Storybook 파일은 대상 컴포넌트와 같은 위치에 둔다
+- 스키마가 늘어나면 `schemas/` 폴더로 분리한다
+
+### Number
+
+- 숫자는 두 자리로 통일
+- `01`, `02`, `03`
+
+---
+
+## 2. Function & Variable
+
+| 대상 | 규칙 | 예시 |
+| --- | --- | --- |
+| Component | `PascalCase` | `ReceiptCard` |
+| Page Component | `PascalCase + Page` | `MainPage` |
+| 변수 | `camelCase` | `receiptList` |
+| 함수 | `camelCase` | `formatDate` |
+| 이벤트 함수 | `handle + 동사` | `handleSubmit` |
+| Event Props | `on + 동사` | `onSubmit` |
+
+### 이벤트 이름
+
+- 대상이 명확하도록 작성
+- `handleReceiptSubmit`
+- `handleModalClose`
+
+### 축약어
+
+- 의미를 알기 어려운 축약어 지양
+- `usrInfo` → `userInfo`
+- `rptData` → `reportData`
+
+---
+
+## 3. Boolean
+
+| Prefix | 사용 기준 | 예시 |
+| --- | --- | --- |
+| `is` | 상태 | `isLoading` |
+| `has` | 보유 여부 | `hasToken` |
+
+---
+
+## 4. Constant
+
+| 대상 | 규칙 | 예시 |
+| --- | --- | --- |
+| 일반 상수 | `UPPER_SNAKE_CASE` | `API_BASE_URL` |
+| CVA 스타일 상수 | `camelCase` | `buttonVariants` |
+
+---
+
+## 5. Props & Type
+
+- `interface` 대신 `type` 사용
+- Component Props는 `ComponentNameProps`
+- HTML Element Props 확장 시 `ComponentProps` 사용
+- Type Import는 `import type` 사용
+- 공통 Type이 아니면 Feature 내부에서 관리
+- `features/{feature}/types.ts`에는 DTO 타입만 작성
+- Component Props 등 그 외 타입은 사용하는 파일 안에 선언
+
+---
+
+## 6. Import
+
+### 경로
+
+- 절대 경로 별칭 `@/` 사용
+- 같은 폴더 내부는 상대 경로 허용
+- 과도한 상대 경로 사용 지양
+
+---
+
+## 7. `index.ts`
+
+- 외부에서 사용할 항목만 Export
+- Export된 항목만 관리
+- 내부 파일 전체 Export 금지
+- 모든 폴더에 생성하지 않음
+- 순환 참조 주의
+
+---
+
+## 8. Asset
+
+### Format
+
+| 형식 | 사용 기준 |
+| --- | --- |
+| SVG | 아이콘, 로고, 단순 일러스트 |
+| PNG | 투명 이미지, 복잡한 UI 이미지 |
+
+### Prefix
+
+| Prefix | 대상 |
+| --- | --- |
+| `ic-` | Icon |
+| `img-` | Image |
+| `logo-` | Logo |
+
+### Rule
+
+- `kebab-case`
+- 숫자는 두 자리
+- 추가 전 경량화
+- 중복 Asset 확인
+- 역할이 드러나는 이름 사용
+
+---
+
+## 9. TSDoc
+
+### 작성 대상
+
+- 공통 Component
+- 사용 방법이 복잡한 Component
+- 중요한 제약이 있는 Hook
+- 재사용되는 Utility
+
+### 작성 내용
+
+- 역할
+- 주요 동작
+- 사용 시 주의사항
+- 필요 시 `@example`
+- `@param`은 선택
+
+> 단순한 Feature 내부 Component는 생략 가능
+
+---
+
+## 10. Comment
+
+| Prefix | 사용 기준 |
+| --- | --- |
+| `TODO` | 추후 구현 또는 수정 |
+| `BUG` | 확인된 버그 |
+| `NOTE` | 중요한 제약 또는 동작 |
+| `OPTIMIZE` | 성능 개선 및 리팩토링 |
+| `INFO` | 참고 정보 |
+
+### Rule
+
+- 주석만 보고 작업 내용을 이해할 수 있도록 작성
+- 작업 완료 후 제거
+- TODO Tree 사용 권장
+
+---
+
+Git/브랜치/커밋/PR 컨벤션은 [GITFLOW.md](./GITFLOW.md)를, 기술 스택과 폴더 구조는 [ARCHITECTURE.md](./ARCHITECTURE.md)를 참고하세요.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #18

## ✅ 체크 사항

- [x] UI 동작 및 레이아웃 확인 (해당 없음 — 문서 작성만)
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

- `docs/CONVENTIONS.md` 추가 — 네이밍, 함수/변수, Boolean, 상수, Props&Type, Import, index.ts, Asset, TSDoc, Comment 규칙
- `docs/ARCHITECTURE.md` 추가 — 기술 스택, 디렉토리 구조(`app/pages/features/shared`), 의존 방향, 상태관리/API 구조 규칙
- `CLAUDE.md` 추가 — 프로젝트 개요, 명령어, 컨벤션/아키텍처 문서 링크, Testing/Gotchas
- 네이티브 래퍼(Capacitor vs React Native)는 아직 미정임을 문서 전반에 명시

### 📸 스크린샷

- 해당 없음

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- `docs/GITFLOW.md`, `AGENTS.md`는 이번 PR엔 미포함 — 링크만 걸려있는 상태예요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 프로젝트 기술 스택과 표준 디렉터리 구조, 의존성 방향을 정리했습니다(React/Vite/TypeScript, 상태·폼·검증·HTTP·스타일 규칙 등).
  * 코드 작성 규칙(네이밍, 타입/Props 작성 원칙, import 및 주석/TSDoc 가이드, 에셋 규칙)을 추가했습니다.
  * 작업 시 참고 컨텍스트를 제공하는 문서를 추가하고 실행 명령어, 테스트/인증·API 원칙, Git 플로우 및 미확정 사항을 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->