### PR TITLE
🐛 [Fix/#96] OAuth 콜백 경로 호환 처리

### DIFF
--- a/apps/web/src/app/providers/AuthProvider.test.tsx
+++ b/apps/web/src/app/providers/AuthProvider.test.tsx
@@ -64,18 +64,21 @@ describe('<AuthProvider />', () => {
     });
   });
 
-  it('OAuth callback에서는 코드 교환 전에 웹 토큰 재발급을 요청하지 않는다', async () => {
-    window.history.replaceState(null, '', '/auth/callback?loginCode=login-code');
+  it.each(['/auth/callback', '/oauth/callback'])(
+    '%s에서는 코드 교환 전에 웹 토큰 재발급을 요청하지 않는다',
+    async (callbackPath) => {
+      window.history.replaceState(null, '', `${callbackPath}?loginCode=login-code`);
 
-    render(
-      <AuthProvider>
-        <p>콜백 화면</p>
-      </AuthProvider>
-    );
+      render(
+        <AuthProvider>
+          <p>콜백 화면</p>
+        </AuthProvider>
+      );
 
-    await waitFor(() => expect(screen.getByText('콜백 화면')).toBeInTheDocument());
-    expect(mockRefreshWeb).not.toHaveBeenCalled();
-  });
+      await waitFor(() => expect(screen.getByText('콜백 화면')).toBeInTheDocument());
+      expect(mockRefreshWeb).not.toHaveBeenCalled();
+    }
+  );
 
   it('앱 시작 시 네이티브 Refresh Token으로 인증 상태를 복원한다', async () => {
     mockIsNativeApp.mockReturnValue(true);

--- a/apps/web/src/app/providers/AuthProvider.tsx
+++ b/apps/web/src/app/providers/AuthProvider.tsx
@@ -19,7 +19,10 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
   useEffect(() => {
-    if (window.location.pathname === ROUTE_PATHS.authCallback) {
+    if (
+      window.location.pathname === ROUTE_PATHS.authCallback ||
+      window.location.pathname === ROUTE_PATHS.oauthCallback
+    ) {
       setInitialized(true);
       return;
     }

--- a/apps/web/src/app/routes/router.tsx
+++ b/apps/web/src/app/routes/router.tsx
@@ -43,6 +43,10 @@ export const router = createBrowserRouter([
             element: <AuthCallbackPage />,
           },
           {
+            path: ROUTE_PATHS.oauthCallback,
+            element: <AuthCallbackPage />,
+          },
+          {
             element: <TermsAgreementRoute />,
             children: [{ path: ROUTE_PATHS.agreement, element: <AgreementPage /> }],
           },

--- a/apps/web/src/shared/constants/routePaths.ts
+++ b/apps/web/src/shared/constants/routePaths.ts
@@ -15,6 +15,7 @@ export const ROUTE_PATTERNS = {
 export const ROUTE_PATHS = {
   login: '/',
   authCallback: '/auth/callback',
+  oauthCallback: '/oauth/callback',
   agreement: '/agreement',
   onboarding: '/onboarding',
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #96

## ✅ 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [ ] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### OAuth 콜백 경로 호환 처리

- 기존 개발 환경의 `/auth/callback` 경로를 유지했습니다.
- 운영 환경에서 전달되는 `/oauth/callback` 경로를 추가했습니다.
- 두 경로가 동일한 OAuth 콜백 페이지를 렌더링하도록 라우터를 수정했습니다.
- 두 콜백 경로에서는 코드 교환 전에 웹 토큰 재발급 요청을 실행하지 않도록 처리했습니다.
- 두 경로에 대한 `AuthProvider` 테스트를 추가했습니다.

### 📸 스크린샷

- 없음

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * OAuth 인증 콜백을 `/oauth/callback` 경로에서도 처리할 수 있습니다.
  * 새 경로에서 기존 인증 콜백 화면과 인증 복원 흐름을 동일하게 제공합니다.

* **버그 수정**
  * OAuth 콜백 처리 중 인증 코드가 교환되기 전에 불필요한 토큰 갱신이 실행되지 않도록 개선했습니다.

* **테스트**
  * 기존 및 신규 OAuth 콜백 경로에 대한 인증 동작 검증을 확장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->