### PR TITLE
🐛 [Fix/#104] 영수증 장소 검색 WebView 무한 로딩 수정

### DIFF
--- a/apps/mobile/src/bridge/index.ts
+++ b/apps/mobile/src/bridge/index.ts
@@ -1,3 +1,4 @@
 export { createBridgeResponse } from './createBridgeResponse';
 export { createResponseScript } from './createResponseScript';
+export { respondToBridgeRequest } from './respondToBridgeRequest';
 export { getTrustedInternalUrl, getUrlOrigin, isTrustedBridgeUrl } from './trustedOrigin';

--- a/apps/mobile/src/bridge/respondToBridgeRequest.test.ts
+++ b/apps/mobile/src/bridge/respondToBridgeRequest.test.ts
@@ -1,0 +1,44 @@
+import { BRIDGE_MESSAGE_KIND } from '@chapchap/shared/bridge';
+
+import { respondToBridgeRequest } from './respondToBridgeRequest';
+
+const TRUSTED_ORIGIN = 'https://chapchap.example.com';
+
+describe('respondToBridgeRequest', () => {
+  it('웹 요청을 처리하고 응답 스크립트를 WebView에 주입한다', async () => {
+    const responseTarget = { injectJavaScript: jest.fn() };
+    const request = {
+      kind: BRIDGE_MESSAGE_KIND.REQUEST,
+      id: 'request-01',
+      type: 'ping',
+      payload: { sentAt: 1 },
+    } as const;
+
+    const isHandled = await respondToBridgeRequest(request, TRUSTED_ORIGIN, responseTarget);
+
+    expect(isHandled).toBe(true);
+    expect(responseTarget.injectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining('request-01')
+    );
+    expect(responseTarget.injectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining(TRUSTED_ORIGIN)
+    );
+  });
+
+  it('브릿지 요청이 아닌 메시지는 처리하지 않는다', async () => {
+    const responseTarget = { injectJavaScript: jest.fn() };
+
+    const isHandled = await respondToBridgeRequest(
+      {
+        kind: BRIDGE_MESSAGE_KIND.EVENT,
+        type: 'routeChanged',
+        payload: { pathname: '/home' },
+      },
+      TRUSTED_ORIGIN,
+      responseTarget
+    );
+
+    expect(isHandled).toBe(false);
+    expect(responseTarget.injectJavaScript).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/bridge/respondToBridgeRequest.ts
+++ b/apps/mobile/src/bridge/respondToBridgeRequest.ts
@@ -1,0 +1,31 @@
+import { isBridgeRequest } from '@chapchap/shared/bridge';
+
+import { createBridgeResponse } from './createBridgeResponse';
+import { createResponseScript } from './createResponseScript';
+
+type BridgeResponseTarget = {
+  injectJavaScript: (script: string) => void;
+};
+
+/**
+ * WebView가 보낸 브릿지 요청을 처리하고 같은 WebView에 응답을 주입합니다.
+ *
+ * 인증 복원처럼 별도 WebView에서도 필요한 네이티브 요청이 누락되지 않도록 화면 간 공통으로
+ * 사용합니다. 호출 전에 메시지를 보낸 URL이 신뢰하는 origin인지 검증해야 합니다.
+ * 요청이 아닌 메시지는 처리하지 않고 `false`를 반환합니다.
+ */
+export const respondToBridgeRequest = async (
+  message: unknown,
+  trustedOrigin: string,
+  responseTarget: BridgeResponseTarget | null
+) => {
+  if (!isBridgeRequest(message)) {
+    return false;
+  }
+
+  const response = await createBridgeResponse(message);
+
+  responseTarget?.injectJavaScript(createResponseScript(response, trustedOrigin));
+
+  return true;
+};

--- a/apps/mobile/src/screens/home/HomeScreen.test.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.test.tsx
@@ -58,6 +58,17 @@ jest.mock('@/bridge', () => ({
   },
   getUrlOrigin: (url: string) => new URL(url).origin,
   isTrustedBridgeUrl: (url: string, trustedOrigin: string) => new URL(url).origin === trustedOrigin,
+  respondToBridgeRequest: async (
+    message: { kind?: string },
+    trustedOrigin: string,
+    responseTarget: { injectJavaScript: (script: string) => void } | null
+  ) => {
+    if (message.kind !== 'request') return false;
+
+    const response = await mockCreateBridgeResponse(message);
+    responseTarget?.injectJavaScript(mockCreateResponseScript(response, trustedOrigin));
+    return true;
+  },
 }));
 
 describe('<HomeScreen />', () => {

--- a/apps/mobile/src/screens/home/HomeScreen.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.tsx
@@ -1,14 +1,13 @@
-import { isBridgeEvent, isBridgeRequest, parseBridgeMessage } from '@chapchap/shared/bridge';
+import { isBridgeEvent, parseBridgeMessage } from '@chapchap/shared/bridge';
 import { useEffect, useRef } from 'react';
 import { BackHandler, Linking } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 import {
-  createBridgeResponse,
-  createResponseScript,
   getTrustedInternalUrl,
   getUrlOrigin,
   isTrustedBridgeUrl,
+  respondToBridgeRequest,
 } from '@/bridge';
 import { subscribeWebViewNavigation } from '@/bridge/webViewNavigation';
 import { WebViewScreen } from '@/shared/layout/WebViewScreen';
@@ -78,14 +77,8 @@ export default function HomeScreen() {
       return;
     }
 
-    if (!isBridgeRequest(message)) {
-      return;
-    }
-
-    const response = await createBridgeResponse(message);
-
     // NOTE: 처리 중 외부 페이지로 이동해도 위치 등 네이티브 응답을 전달하지 않는다.
-    webViewRef.current?.injectJavaScript(createResponseScript(response, trustedWebOrigin));
+    await respondToBridgeRequest(message, trustedWebOrigin, webViewRef.current);
   };
 
   const handleShouldStartLoadWithRequest: NonNullable<

--- a/apps/mobile/src/screens/place-search/PlaceSearchScreen.test.tsx
+++ b/apps/mobile/src/screens/place-search/PlaceSearchScreen.test.tsx
@@ -5,6 +5,8 @@ import { requestWebViewNavigation } from '@/bridge/webViewNavigation';
 
 import PlaceSearchScreen from './PlaceSearchScreen';
 
+const mockRespondToBridgeRequest = jest.fn();
+
 const reviewParams = {
   uri: 'file://receipt.jpg',
   shopName: '기존 가게',
@@ -19,6 +21,12 @@ jest.mock('expo-router', () => ({
   router: { back: jest.fn(), dismissTo: jest.fn() },
   useLocalSearchParams: () => reviewParams,
 }));
+jest.mock('@/bridge', () => ({
+  getUrlOrigin: (url: string) => new URL(url).origin,
+  isTrustedBridgeUrl: (url: string, trustedOrigin: string) => new URL(url).origin === trustedOrigin,
+  respondToBridgeRequest: (message: unknown, trustedOrigin: string, webView: unknown) =>
+    mockRespondToBridgeRequest(message, trustedOrigin, webView),
+}));
 jest.mock('@/bridge/webViewNavigation', () => ({ requestWebViewNavigation: jest.fn() }));
 
 describe('<PlaceSearchScreen />', () => {
@@ -27,6 +35,7 @@ describe('<PlaceSearchScreen />', () => {
   beforeEach(() => {
     process.env.EXPO_PUBLIC_WEB_URL = 'http://192.168.0.2:5173/record/receipt/camera';
     jest.clearAllMocks();
+    mockRespondToBridgeRequest.mockResolvedValue(true);
   });
 
   afterAll(() => {
@@ -51,6 +60,50 @@ describe('<PlaceSearchScreen />', () => {
     expect(getByTestId('place-search-webview')).toHaveProp('source', {
       uri: 'http://192.168.0.2:5173/record/shop/search?source=receipt-native',
     });
+  });
+
+  it('검색 WebView의 인증용 브릿지 요청을 처리한다', async () => {
+    const bridgeRequest = {
+      kind: 'request',
+      id: 'request-auth-01',
+      type: 'getRefreshToken',
+      payload: {},
+    };
+    const { getByTestId } = await render(<PlaceSearchScreen />);
+
+    await act(async () => {
+      await getByTestId('place-search-webview').props.onMessage({
+        nativeEvent: {
+          url: 'http://192.168.0.2:5173/record/shop/search?source=receipt-native',
+          data: JSON.stringify(bridgeRequest),
+        },
+      });
+    });
+
+    expect(mockRespondToBridgeRequest.mock.calls[0]?.slice(0, 2)).toEqual([
+      bridgeRequest,
+      'http://192.168.0.2:5173',
+    ]);
+  });
+
+  it('설정된 웹 주소와 다른 origin의 인증 요청은 처리하지 않는다', async () => {
+    const { getByTestId } = await render(<PlaceSearchScreen />);
+
+    await act(async () => {
+      await getByTestId('place-search-webview').props.onMessage({
+        nativeEvent: {
+          url: 'https://evil.example.com/record/shop/search',
+          data: JSON.stringify({
+            kind: 'request',
+            id: 'request-auth-02',
+            type: 'getRefreshToken',
+            payload: {},
+          }),
+        },
+      });
+    });
+
+    expect(mockRespondToBridgeRequest).not.toHaveBeenCalled();
   });
 
   it('웹에서 선택한 가게와 기존 작성값을 리뷰 화면으로 돌려준다', async () => {

--- a/apps/mobile/src/screens/place-search/PlaceSearchScreen.tsx
+++ b/apps/mobile/src/screens/place-search/PlaceSearchScreen.tsx
@@ -7,7 +7,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useRef } from 'react';
 import { WebView } from 'react-native-webview';
 
-import { getUrlOrigin, isTrustedBridgeUrl } from '@/bridge';
+import { getUrlOrigin, isTrustedBridgeUrl, respondToBridgeRequest } from '@/bridge';
 import { requestWebViewNavigation } from '@/bridge/webViewNavigation';
 import type { ReceiptReviewRouteParams } from '@/features/record';
 import { WebViewScreen } from '@/shared/layout/WebViewScreen';
@@ -24,7 +24,7 @@ export default function PlaceSearchScreen() {
   const webViewRef = useRef<WebView>(null);
   const searchUrl = trustedWebOrigin ? `${trustedWebOrigin}${SHOP_SEARCH_PATH}` : null;
 
-  const handleBridgeMessage = (event: WebViewMessageEvent) => {
+  const handleBridgeMessage = async (event: WebViewMessageEvent) => {
     if (!trustedWebOrigin || !isTrustedBridgeUrl(event.nativeEvent.url, trustedWebOrigin)) {
       return;
     }
@@ -32,6 +32,7 @@ export default function PlaceSearchScreen() {
     const message = parseBridgeMessage(event.nativeEvent.data);
 
     if (!isBridgeEvent(message)) {
+      await respondToBridgeRequest(message, trustedWebOrigin, webViewRef.current);
       return;
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #104

## ✅ 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [ ] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### 장소 검색 WebView 인증 복원 수정

- 영수증 확인 화면에서 장소 변경 시 별도 검색 WebView가 인증 브릿지 요청을 처리하도록 수정했습니다.
- `getRefreshToken`, `saveRefreshToken` 등의 요청에 응답하지 않아 인증 화면이 계속 로딩되던 문제를 해결했습니다.
- WebView 브릿지 요청과 응답 스크립트 주입 로직을 공통 유틸로 분리했습니다.
- 홈 WebView도 동일한 공통 브릿지 처리 로직을 사용하도록 정리했습니다.

### 테스트

- 장소 검색 WebView의 인증 요청 처리 회귀 테스트를 추가했습니다.
- 신뢰하지 않는 origin의 인증 요청을 무시하는 테스트를 추가했습니다.
- 모바일 전체 테스트 31개 suite, 139개 테스트 통과
- 모바일 타입 검사 및 린트 통과

### 📸 스크린샷

- UI 변경 없음
- iOS 실기기에서 `영수증 인식 → 장소 변경 → 장소 검색` 플로우 확인 필요

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 별도 장소 검색 WebView에서도 인증 토큰 복원 요청과 응답이 정상적으로 처리되는지 확인 부탁드립니다.
- 공통 브릿지 응답 처리 함수의 위치와 책임이 적절한지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모바일 앱의 브리지 요청 처리 기능을 통합했습니다.
  - 신뢰된 출처의 유효한 요청에 응답하고 WebView에 결과를 전달합니다.
  - 브리지 요청이 아닌 메시지와 신뢰되지 않은 출처의 요청은 무시합니다.
  - 응답 대상 WebView가 없는 경우에도 앱이 안정적으로 동작합니다.

- **버그 수정**
  - 홈 및 장소 검색 화면에서 브리지 응답 처리를 일관되게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->