### PR TITLE
✨ [Feat/#100] 영수증 카메라 및 기록 완료 흐름 개선

### DIFF
--- a/apps/mobile/src/features/record/apis/types.ts
+++ b/apps/mobile/src/features/record/apis/types.ts
@@ -1,3 +1,12 @@
+export type GooglePlaceSearchResultResponse = {
+  googlePlaceId?: string;
+  placeName?: string;
+  roadAddress?: string;
+  latitude?: number;
+  longitude?: number;
+  thumbnailUrl?: string | null;
+};
+
 export type ReceiptOcrResponse = {
   receiptImageId: number;
   storeName?: string | null;
@@ -5,6 +14,7 @@ export type ReceiptOcrResponse = {
   purchaseDate?: string | null;
   purchaseTime?: string | null;
   amount?: number | null;
+  googlePlaceSearchResult?: GooglePlaceSearchResultResponse;
 };
 
 export type ConsumptionCreateRequest = {
@@ -22,4 +32,6 @@ export type ConsumptionCreateRequest = {
 
 export type ConsumptionCreateResponse = {
   consumptionId?: number;
+  stickerCategory?: string;
+  stickerName?: string;
 };

--- a/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.test.ts
+++ b/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.test.ts
@@ -52,6 +52,7 @@ describe('useSubmitReceiptConsumption', () => {
       category: '카페',
     });
     expect(mockShowToast).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onSuccess).toHaveBeenCalledWith({
       placeName: '카페 차차',
       latitude: 37.5,

--- a/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.test.ts
+++ b/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.test.ts
@@ -51,11 +51,12 @@ describe('useSubmitReceiptConsumption', () => {
       amount: 12000,
       category: '카페',
     });
-    expect(mockShowToast).toHaveBeenCalledWith({
-      type: 'success',
-      message: '소비 기록이 저장되었어요.',
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith({
+      placeName: '카페 차차',
+      latitude: 37.5,
+      longitude: 127,
     });
-    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
   it('저장 실패 시 서버 메시지를 보여주고 성공 콜백은 호출하지 않는다', async () => {

--- a/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.ts
+++ b/apps/mobile/src/features/record/hooks/useSubmitReceiptConsumption.ts
@@ -6,18 +6,20 @@ import { createConsumptionRequest } from '@/features/record/utils/createConsumpt
 import { getRecordErrorMessage } from '@/features/record/utils/getRecordErrorMessage';
 import { useToast } from '@/shared/ui/toast';
 
+import type { CreatedConsumptionPlace } from '@chapchap/shared/record';
+
 const CREATE_CONSUMPTION_ERROR_MESSAGE =
   '소비 기록을 저장하지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const CREATE_CONSUMPTION_SUCCESS_MESSAGE = '소비 기록이 저장되었어요.';
 
 type UseSubmitReceiptConsumptionOptions = {
-  onSuccess: () => void;
+  onSuccess: (createdPlace: CreatedConsumptionPlace) => void;
 };
 
 /**
  * 확인한 영수증 기록의 요청 변환·저장·피드백을 담당한다.
  *
- * 성공 뒤 화면 전환은 화면 계층이 결정할 수 있도록 `onSuccess`에 위임한다.
+ * 성공 뒤 화면 전환은 화면 계층이 결정할 수 있도록 `onSuccess`에 위임하며, 지도 홈이
+ * 방문 마커와 대조할 수 있도록 등록한 장소명·좌표를 함께 전달한다.
  */
 export const useSubmitReceiptConsumption = ({ onSuccess }: UseSubmitReceiptConsumptionOptions) => {
   const { showToast } = useToast();
@@ -33,9 +35,13 @@ export const useSubmitReceiptConsumption = ({ onSuccess }: UseSubmitReceiptConsu
     setIsSubmitting(true);
 
     try {
-      await createConsumption(createConsumptionRequest(draft));
-      showToast({ type: 'success', message: CREATE_CONSUMPTION_SUCCESS_MESSAGE });
-      onSuccess();
+      const request = createConsumptionRequest(draft);
+      await createConsumption(request);
+      onSuccess({
+        placeName: request.placeName,
+        latitude: request.latitude,
+        longitude: request.longitude,
+      });
     } catch (error) {
       showToast({
         type: 'error',

--- a/apps/mobile/src/features/record/index.ts
+++ b/apps/mobile/src/features/record/index.ts
@@ -14,5 +14,6 @@ export {
   parseVisitDateTime,
 } from './utils/receiptReviewParams';
 export { parseReceiptVisitDateTime } from './utils/parseReceiptVisitDateTime';
+export { createRecordCreatedHomePath } from './utils/createRecordCreatedHomePath';
 
 export type { ReceiptDraft, ReceiptReviewRouteParams, ReceiptReviewState } from './types';

--- a/apps/mobile/src/features/record/utils/createRecordCreatedHomePath.test.ts
+++ b/apps/mobile/src/features/record/utils/createRecordCreatedHomePath.test.ts
@@ -1,0 +1,15 @@
+import { createRecordCreatedHomePath } from './createRecordCreatedHomePath';
+
+describe('createRecordCreatedHomePath', () => {
+  it('장소명과 좌표를 쿼리 문자열로 인코딩한 홈 경로를 만든다', () => {
+    expect(
+      createRecordCreatedHomePath({
+        placeName: '카페 차차',
+        latitude: 37.506481,
+        longitude: 127.024551,
+      })
+    ).toBe(
+      '/home?createdPlaceName=%EC%B9%B4%ED%8E%98+%EC%B0%A8%EC%B0%A8&createdPlaceLat=37.506481&createdPlaceLng=127.024551'
+    );
+  });
+});

--- a/apps/mobile/src/features/record/utils/createRecordCreatedHomePath.ts
+++ b/apps/mobile/src/features/record/utils/createRecordCreatedHomePath.ts
@@ -1,0 +1,24 @@
+import { CREATED_CONSUMPTION_QUERY_KEYS } from '@chapchap/shared/record';
+
+import type { CreatedConsumptionPlace } from '@chapchap/shared/record';
+
+/**
+ * 방금 등록한 소비 기록의 장소 정보를 지도 홈 WebView 이동 경로에 실어 보낸다.
+ *
+ * 네이티브에서 웹으로의 이동은 `window.location.replace`로 문서 전체를 새로 로드하므로
+ * JS 상태를 그대로 넘길 수 없다. 쿼리 문자열로 인코딩해 홈 화면이 도착 직후 지도 포커스와
+ * 완료 안내에 사용할 수 있게 한다.
+ */
+export const createRecordCreatedHomePath = ({
+  placeName,
+  latitude,
+  longitude,
+}: CreatedConsumptionPlace) => {
+  const params = new URLSearchParams({
+    [CREATED_CONSUMPTION_QUERY_KEYS.placeName]: placeName,
+    [CREATED_CONSUMPTION_QUERY_KEYS.latitude]: String(latitude),
+    [CREATED_CONSUMPTION_QUERY_KEYS.longitude]: String(longitude),
+  });
+
+  return `/home?${params.toString()}`;
+};

--- a/apps/mobile/src/screens/camera/ReceiptCameraScreen.test.tsx
+++ b/apps/mobile/src/screens/camera/ReceiptCameraScreen.test.tsx
@@ -80,6 +80,14 @@ describe('<ReceiptCameraScreen />', () => {
       purchaseDate: '2026-07-25',
       purchaseTime: '11:20:00',
       amount: 33000,
+      googlePlaceSearchResult: {
+        googlePlaceId: 'ChIJ-two-some',
+        placeName: '투썸플레이스 신논현점',
+        roadAddress: '서울특별시 강남구 봉은사로 125 1층',
+        latitude: 37.506481,
+        longitude: 127.024551,
+        thumbnailUrl: 'https://example.com/twosome.jpg',
+      },
     });
     const { getByRole } = await render(<ReceiptCameraScreen />);
 
@@ -101,8 +109,12 @@ describe('<ReceiptCameraScreen />', () => {
       params: {
         uri: 'file://normalized.jpg',
         receiptImageId: '15',
+        shopId: 'ChIJ-two-some',
         shopName: '투썸플레이스 신논현점',
         shopAddress: '서울특별시 강남구 봉은사로 125 1층',
+        shopPhotoUrl: 'https://example.com/twosome.jpg',
+        latitude: '37.506481',
+        longitude: '127.024551',
         amount: '33000',
         visitedAt: String(new Date(2026, 6, 25, 11, 20).getTime()),
         visitPeriod: 'afternoon',

--- a/apps/mobile/src/screens/camera/ReceiptCameraScreen.tsx
+++ b/apps/mobile/src/screens/camera/ReceiptCameraScreen.tsx
@@ -1,7 +1,7 @@
 import { CameraView } from 'expo-camera';
 import { router } from 'expo-router';
-import { useRef, useState } from 'react';
-import { Alert, Pressable, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, PanResponder, Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { requestWebViewNavigation } from '@/bridge/webViewNavigation';
@@ -19,7 +19,23 @@ import { CloseIcon, GalleryIcon } from '@/shared/assets/icons';
 import { BackButton } from '@/shared/ui/back-button';
 import { useToast } from '@/shared/ui/toast';
 
+import type { GestureResponderEvent } from 'react-native';
+
 type ProcessedReceipt = Awaited<ReturnType<typeof processReceiptImage>>;
+
+// NOTE: 손가락 이동 거리 대비 줌 변화량. 실제 기기에서 체감 속도를 보고 조정이 필요할 수 있다.
+const PINCH_ZOOM_SENSITIVITY = 0.5;
+const ULTRA_WIDE_LENS_PATTERN = /ultra[ -]?wide|울트라[ -]?와이드|초광각/i;
+
+const getTouchDistance = (touches: GestureResponderEvent['nativeEvent']['touches']) => {
+  const [first, second] = touches;
+
+  if (!first || !second) {
+    return 0;
+  }
+
+  return Math.hypot(first.pageX - second.pageX, first.pageY - second.pageY);
+};
 
 const createReceiptConfirmParams = ({
   uri,
@@ -29,14 +45,29 @@ const createReceiptConfirmParams = ({
   purchaseDate,
   purchaseTime,
   amount,
+  googlePlaceSearchResult,
 }: ProcessedReceipt): ReceiptReviewRouteParams => {
   const visitDateTime = parseReceiptVisitDateTime(purchaseDate, purchaseTime);
+  const recognizedShopName = googlePlaceSearchResult?.placeName || storeName;
+  const recognizedShopAddress = googlePlaceSearchResult?.roadAddress || address;
 
   return {
     uri,
     receiptImageId: String(receiptImageId),
-    ...(storeName ? { shopName: storeName } : {}),
-    ...(address ? { shopAddress: address } : {}),
+    ...(googlePlaceSearchResult?.googlePlaceId
+      ? { shopId: googlePlaceSearchResult.googlePlaceId }
+      : {}),
+    ...(recognizedShopName ? { shopName: recognizedShopName } : {}),
+    ...(recognizedShopAddress ? { shopAddress: recognizedShopAddress } : {}),
+    ...(googlePlaceSearchResult?.thumbnailUrl
+      ? { shopPhotoUrl: googlePlaceSearchResult.thumbnailUrl }
+      : {}),
+    ...(googlePlaceSearchResult?.latitude !== undefined
+      ? { latitude: String(googlePlaceSearchResult.latitude) }
+      : {}),
+    ...(googlePlaceSearchResult?.longitude !== undefined
+      ? { longitude: String(googlePlaceSearchResult.longitude) }
+      : {}),
     ...(amount !== null && amount !== undefined ? { amount: String(amount) } : {}),
     ...(visitDateTime
       ? {
@@ -61,6 +92,16 @@ export default function ReceiptCameraScreen() {
   const isProcessingRef = useRef(false);
   const isScanVisibleRef = useRef(false);
   const [isCameraReady, setIsCameraReady] = useState(false);
+  const [zoom, setZoom] = useState(0);
+  const zoomRef = useRef(0);
+  const [selectedLens, setSelectedLens] = useState<string | undefined>(undefined);
+  const selectedLensRef = useRef<string | undefined>(undefined);
+  const ultraWideLensRef = useRef<string | undefined>(undefined);
+  const pinchStartRef = useRef<{
+    distance: number;
+    zoom: number;
+    lens: string | undefined;
+  } | null>(null);
   // NOTE: 촬영과 갤러리 선택 중 하나만 동시에 진행될 수 있어 상태 하나로 함께 관리한다.
   const [isProcessing, setIsProcessing] = useState(false);
   const [isExitConfirmOpen, setIsExitConfirmOpen] = useState(false);
@@ -75,6 +116,98 @@ export default function ReceiptCameraScreen() {
     setIsProcessing(false);
     setScanImageUri(null);
   };
+
+  const updateZoom = useCallback((value: number) => {
+    zoomRef.current = value;
+    setZoom(value);
+  }, []);
+
+  const updateSelectedLens = useCallback((value?: string) => {
+    selectedLensRef.current = value;
+    setSelectedLens(value);
+  }, []);
+
+  const handleCameraReady = () => {
+    setIsCameraReady(true);
+
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
+    // NOTE: onCameraReady는 async로 넘기면 안 된다(호출부가 반환값을 함수로 기대할 수 있다).
+    // 렌즈 목록 조회는 별도로 fire-and-forget한다.
+    void (async () => {
+      try {
+        const availableLenses = (await cameraRef.current?.getAvailableLensesAsync()) ?? [];
+        ultraWideLensRef.current = availableLenses.find((lens) =>
+          ULTRA_WIDE_LENS_PATTERN.test(lens)
+        );
+      } catch {
+        // NOTE: 렌즈 목록 조회에 실패해도 기본 렌즈로는 계속 촬영할 수 있어 조용히 무시한다.
+        ultraWideLensRef.current = undefined;
+      }
+    })();
+  };
+
+  const [pinchPanHandlers, setPinchPanHandlers] = useState<
+    ReturnType<typeof PanResponder.create>['panHandlers']
+  >({});
+
+  useEffect(() => {
+    const responder = PanResponder.create({
+      onStartShouldSetPanResponder: (event) => event.nativeEvent.touches.length === 2,
+      onMoveShouldSetPanResponder: (event) => event.nativeEvent.touches.length === 2,
+      onPanResponderGrant: (event) => {
+        pinchStartRef.current = {
+          distance: getTouchDistance(event.nativeEvent.touches),
+          zoom: zoomRef.current,
+          lens: selectedLensRef.current,
+        };
+      },
+      onPanResponderMove: (event) => {
+        const pinchStart = pinchStartRef.current;
+
+        if (!pinchStart || event.nativeEvent.touches.length !== 2 || pinchStart.distance === 0) {
+          return;
+        }
+
+        const distance = getTouchDistance(event.nativeEvent.touches);
+        const scale = distance / pinchStart.distance;
+        const nextZoom = pinchStart.zoom + (scale - 1) * PINCH_ZOOM_SENSITIVITY;
+
+        // NOTE: 기본 렌즈에서 계속 축소하면(줌 < 0) iOS에서만 초광각 렌즈로 전환한다.
+        // 이 지점을 새 제스처 기준점으로 삼아 이어서 손가락을 움직여도 자연스럽게 이어지게 한다.
+        if (pinchStart.lens === undefined && nextZoom < 0 && ultraWideLensRef.current) {
+          updateSelectedLens(ultraWideLensRef.current);
+          updateZoom(0);
+          pinchStartRef.current = { distance, zoom: 0, lens: ultraWideLensRef.current };
+          return;
+        }
+
+        // NOTE: 초광각에서 다시 확대 방향으로 돌리면 기본 렌즈로 복귀한다.
+        if (
+          ultraWideLensRef.current &&
+          pinchStart.lens === ultraWideLensRef.current &&
+          nextZoom > 0
+        ) {
+          updateSelectedLens(undefined);
+          updateZoom(0);
+          pinchStartRef.current = { distance, zoom: 0, lens: undefined };
+          return;
+        }
+
+        updateZoom(Math.min(1, Math.max(0, nextZoom)));
+      },
+      onPanResponderRelease: () => {
+        pinchStartRef.current = null;
+      },
+      onPanResponderTerminate: () => {
+        pinchStartRef.current = null;
+      },
+    });
+
+    setPinchPanHandlers(responder.panHandlers);
+  }, [updateSelectedLens, updateZoom]);
 
   const showScanLoading = (imageUri: string) => {
     isScanVisibleRef.current = true;
@@ -164,13 +297,15 @@ export default function ReceiptCameraScreen() {
   }
 
   return (
-    <View className="flex-1 bg-neutral-900">
+    <View className="flex-1 bg-neutral-900" {...pinchPanHandlers}>
       {/* NOTE: CameraView는 react-native 외부 컴포넌트라 Uniwind의 className이 적용되지 않으므로 style을 쓴다. */}
       <CameraView
         ref={cameraRef}
         style={{ flex: 1 }}
         facing="back"
-        onCameraReady={() => setIsCameraReady(true)}
+        zoom={zoom}
+        selectedLens={Platform.OS === 'ios' ? selectedLens : undefined}
+        onCameraReady={handleCameraReady}
       />
 
       <View pointerEvents="none" className="absolute inset-x-0 top-0 h-33.5 bg-neutral-900/80" />

--- a/apps/mobile/src/screens/receipt-confirm/ReceiptConfirmScreen.test.tsx
+++ b/apps/mobile/src/screens/receipt-confirm/ReceiptConfirmScreen.test.tsx
@@ -122,11 +122,10 @@ describe('<ReceiptConfirmScreen />', () => {
       amount: 12000,
       category: '카페',
     });
-    expect(requestWebViewNavigation).toHaveBeenCalledWith('/home');
-    expect(mockShowToast).toHaveBeenCalledWith({
-      type: 'success',
-      message: '소비 기록이 저장되었어요.',
-    });
+    expect(requestWebViewNavigation).toHaveBeenCalledWith(
+      '/home?createdPlaceName=%EC%B9%B4%ED%8E%98+%EC%B0%A8%EC%B0%A8&createdPlaceLat=37.506481&createdPlaceLng=127.024551'
+    );
+    expect(mockShowToast).not.toHaveBeenCalled();
     expect(router.dismissTo).toHaveBeenCalledWith('/');
   });
 });

--- a/apps/mobile/src/screens/receipt-confirm/ReceiptConfirmScreen.tsx
+++ b/apps/mobile/src/screens/receipt-confirm/ReceiptConfirmScreen.tsx
@@ -3,12 +3,15 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { requestWebViewNavigation } from '@/bridge/webViewNavigation';
 import {
   createReceiptReviewRouteParams,
+  createRecordCreatedHomePath,
   isRecordCategory,
   parseVisitDateTime,
   ReceiptReviewForm,
   useSubmitReceiptConsumption,
 } from '@/features/record';
 import type { ReceiptReviewRouteParams } from '@/features/record';
+
+import type { CreatedConsumptionPlace } from '@chapchap/shared/record';
 
 const parseRouteNumber = (value: string | undefined) => {
   if (!value) {
@@ -49,12 +52,16 @@ export default function ReceiptConfirmScreen() {
     router.dismissTo('/');
   };
 
+  const handleSubmitSuccess = (createdPlace: CreatedConsumptionPlace) => {
+    requestWebViewNavigation(createRecordCreatedHomePath(createdPlace));
+    router.dismissTo('/');
+  };
+
   const { isSubmitting, submitReceiptConsumption } = useSubmitReceiptConsumption({
-    onSuccess: handleClose,
+    onSuccess: handleSubmitSuccess,
   });
 
   const handleBack = () => {
-    // TODO: 공통 확인 UI 디자인 확정 후 작성 중 이탈 안내를 거쳐 카메라로 이동한다.
     router.replace('/camera');
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #100

## ✅ 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### 영수증 카메라 줌 개선

- 핀치 제스처를 이용한 카메라 줌을 추가했습니다.
- 줌 아웃 시 지원되는 기기에서 초광각 카메라로 전환되도록 구현했습니다.
- 카메라 전환 과정에서 줌 값이 자연스럽게 이어지도록 처리했습니다.
- 일반 카메라와 초광각 카메라의 경계 동작을 테스트했습니다.

### 소비 기록 완료 후 지도 안내

- 소비 기록 생성 응답에서 장소명과 좌표를 유지하도록 타입을 확장했습니다.
- 생성된 장소 정보를 지도 홈 경로의 query parameter로 인코딩합니다.
- 영수증 기록 완료 후 메인 WebView의 지도 홈으로 이동하도록 변경했습니다.
- 장소 안내 경로 생성과 화면 이동 흐름 테스트를 추가했습니다.

### 선행 PR 의존성

- 이 PR은 `feat/home-api-web-100`의 공통 장소 전달 타입과 지도 홈 처리 로직을 사용합니다.
- 웹 홈 API PR이 먼저 merge되어야 합니다.
- 선행 PR merge 후 이 브랜치를 최신 `develop` 위로 rebase하고 PR base를 `develop`으로 변경합니다.

### 테스트 및 검증

- 전체 타입체크를 통과했습니다.
- 모바일 테스트 33개 스위트, 142개 테스트를 통과했습니다.
- ESLint와 Prettier 검사를 통과했습니다.
- Android 및 iOS Expo export를 확인했습니다.

### 📸 스크린샷

- 핀치 줌 및 초광각 카메라 전환 화면
- 영수증 기록 완료 후 지도 홈 장소 안내 화면

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 핀치 줌과 카메라 장치 전환 경계에서 상태가 안정적인지 확인 부탁드립니다.
- 이 PR은 stacked PR이므로 `feat/home-api-web-100`을 base로 리뷰 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 카메라 화면에서 핀치 줌과 iOS 초광각 렌즈 전환을 지원합니다.
  - 영수증 인식 결과에 상점명, 주소, 사진, 좌표 등 장소 정보를 표시하고 전달합니다.
  - 기록 저장 후 생성된 장소 정보가 포함된 홈 화면으로 이동합니다.
  - 소비 기록에 스티커 카테고리와 이름 정보를 지원합니다.

- **개선 사항**
  - 기록 저장 성공 시 불필요한 성공 토스트 표시를 제거했습니다.
  - 장소명과 위치 정보가 안전하게 인코딩되어 화면 이동에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->