### PR TITLE
✨ [Feat/#133] 소비한 곳 검색 화면에 최근 검색어 기능 추가

### DIFF
--- a/apps/web/src/features/shop/components/visited-place-search/RecentSearchList.test.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/RecentSearchList.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RecentSearchList } from './RecentSearchList';
+
+describe('RecentSearchList', () => {
+  it('최근 검색어가 없으면 아무것도 렌더링하지 않는다', () => {
+    const { container } = render(
+      <RecentSearchList keywords={[]} onSelect={jest.fn()} onRemove={jest.fn()} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('최근 검색어 목록을 순서대로 표시한다', () => {
+    render(
+      <RecentSearchList keywords={['투썸', '카페']} onSelect={jest.fn()} onRemove={jest.fn()} />
+    );
+
+    expect(screen.getByText('최근 검색어')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('투썸');
+    expect(items[1]).toHaveTextContent('카페');
+  });
+
+  it('검색어를 클릭하면 onSelect에 해당 검색어를 전달한다', async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    render(<RecentSearchList keywords={['투썸']} onSelect={onSelect} onRemove={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '투썸' }));
+
+    expect(onSelect).toHaveBeenCalledWith('투썸');
+  });
+
+  it('삭제 버튼을 클릭하면 onRemove에 해당 검색어를 전달한다', async () => {
+    const user = userEvent.setup();
+    const onRemove = jest.fn();
+    render(<RecentSearchList keywords={['투썸']} onSelect={jest.fn()} onRemove={onRemove} />);
+
+    await user.click(screen.getByRole('button', { name: '투썸 최근 검색어 삭제' }));
+
+    expect(onRemove).toHaveBeenCalledWith('투썸');
+  });
+});

--- a/apps/web/src/features/shop/components/visited-place-search/RecentSearchList.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/RecentSearchList.tsx
@@ -1,0 +1,45 @@
+import { CloseIcon } from '@/shared/assets/icons';
+
+type RecentSearchListProps = {
+  keywords: readonly string[];
+  onRemove: (keyword: string) => void;
+  onSelect: (keyword: string) => void;
+};
+
+/** 검색어를 입력하기 전, 최근 검색어를 칩 목록으로 보여줍니다. */
+export function RecentSearchList({ keywords, onRemove, onSelect }: RecentSearchListProps) {
+  if (keywords.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8">
+      <p className="text-body-01-semibold text-neutral-700">최근 검색어</p>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {keywords.map((keyword) => (
+          <li
+            key={keyword}
+            className="flex items-center gap-1 rounded-full border border-neutral-300 bg-neutral-00 py-1.5 pl-3 pr-2"
+          >
+            <button
+              type="button"
+              onClick={() => onSelect(keyword)}
+              className="max-w-40 truncate text-body-02-medium text-neutral-600"
+            >
+              {keyword}
+            </button>
+            <button
+              type="button"
+              aria-label={`${keyword} 최근 검색어 삭제`}
+              onClick={() => onRemove(keyword)}
+              className="flex size-4 shrink-0 items-center justify-center text-neutral-500"
+            >
+              <CloseIcon aria-hidden="true" className="size-2.5" />
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="-mx-4 mt-8 h-2 bg-neutral-100" aria-hidden="true" />
+    </div>
+  );
+}

--- a/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.test.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.test.tsx
@@ -137,6 +137,28 @@ describe('VisitedPlaceSearch', () => {
     expect(screen.getByText('서울특별시 강남구 봉은사로 125 1층')).toBeInTheDocument();
   });
 
+  it('같은 최근 검색어를 지웠다가 다시 클릭해도 재검색한다', async () => {
+    const user = userEvent.setup();
+    render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('검색어를 입력해주세요');
+    await user.type(input, '투썸');
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.click(screen.getByRole('button', { name: /투썸플레이스/ }));
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+
+    await user.click(screen.getByRole('button', { name: '투썸' }));
+    expect(input).toHaveValue('투썸');
+
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.click(screen.getByRole('button', { name: '투썸' }));
+
+    expect(input).toHaveValue('투썸');
+    expect(screen.getByText('서울특별시 강남구 봉은사로 125 1층')).toBeInTheDocument();
+  });
+
   it('최근 검색어를 삭제할 수 있다', async () => {
     const user = userEvent.setup();
     render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);

--- a/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.test.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.test.tsx
@@ -11,6 +11,7 @@ const mockedUseVisitedPlaceSearchInfiniteQuery = jest.mocked(useVisitedPlaceSear
 
 describe('VisitedPlaceSearch', () => {
   beforeEach(() => {
+    window.localStorage.clear();
     mockedUseVisitedPlaceSearchInfiniteQuery.mockImplementation(
       (keyword) =>
         ({
@@ -89,5 +90,66 @@ describe('VisitedPlaceSearch', () => {
     expect(screen.getByText('투썸플레이스')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: '다시 불러오기' }));
     expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('검색 결과에서 매장을 선택하면 검색어가 최근 검색어로 저장된다', async () => {
+    const user = userEvent.setup();
+    render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('검색어를 입력해주세요');
+    await user.type(input, '투썸');
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.click(screen.getByRole('button', { name: /투썸플레이스/ }));
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+
+    expect(screen.getByText('최근 검색어')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '투썸' })).toBeInTheDocument();
+  });
+
+  it('매장을 선택하지 않고 검색만 하면 최근 검색어로 저장하지 않는다', async () => {
+    const user = userEvent.setup();
+    render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('검색어를 입력해주세요');
+    await user.type(input, '투썸');
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+
+    expect(screen.queryByText('최근 검색어')).not.toBeInTheDocument();
+  });
+
+  it('최근 검색어를 클릭하면 해당 검색어로 다시 검색한다', async () => {
+    const user = userEvent.setup();
+    render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('검색어를 입력해주세요');
+    await user.type(input, '투썸');
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.click(screen.getByRole('button', { name: /투썸플레이스/ }));
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+
+    await user.click(screen.getByRole('button', { name: '투썸' }));
+
+    expect(input).toHaveValue('투썸');
+    expect(screen.getByText('서울특별시 강남구 봉은사로 125 1층')).toBeInTheDocument();
+  });
+
+  it('최근 검색어를 삭제할 수 있다', async () => {
+    const user = userEvent.setup();
+    render(<VisitedPlaceSearch onSelectPlace={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText('검색어를 입력해주세요');
+    await user.type(input, '투썸');
+    await user.click(screen.getByRole('button', { name: '검색' }));
+    await user.click(screen.getByRole('button', { name: /투썸플레이스/ }));
+    await user.clear(input);
+    await user.click(screen.getByRole('button', { name: '검색' }));
+
+    await user.click(screen.getByRole('button', { name: '투썸 최근 검색어 삭제' }));
+
+    expect(screen.queryByText('최근 검색어')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.tsx
@@ -7,6 +7,9 @@ import { PlaceSearchInput, PlaceSearchResultList } from '@/shared/ui/place-searc
 import type { PlaceSearchItem } from '@/shared/ui/place-search';
 import { Spinner } from '@/shared/ui/spinner';
 
+import { RecentSearchList } from './RecentSearchList';
+import { useRecentSearches } from './useRecentSearches';
+
 type VisitedPlaceSearchProps = {
   onSelectPlace: (placeId: string) => void;
 };
@@ -18,8 +21,17 @@ type VisitedPlaceSearchItem = PlaceSearchItem & {
 /** 소비 기록이 있는 장소만 매장명과 주소로 검색합니다. */
 export default function VisitedPlaceSearch({ onSelectPlace }: VisitedPlaceSearchProps) {
   const [keyword, setKeyword] = useState('');
+  const [appliedKeyword, setAppliedKeyword] = useState<string>();
+  const { addRecentSearch, recentSearches, removeRecentSearch } = useRecentSearches();
   const searchQuery = useVisitedPlaceSearchInfiniteQuery(keyword);
   const { fetchNextPage, hasNextPage, isFetchNextPageError, isFetchingNextPage } = searchQuery;
+  const hasKeyword = keyword.trim().length > 0;
+
+  const handleSelectPlace = (placeId: string) => {
+    addRecentSearch(keyword);
+    onSelectPlace(placeId);
+  };
+
   const matchedPlaces = useMemo<VisitedPlaceSearchItem[]>(
     () =>
       (searchQuery.data?.pages ?? []).flatMap((page) =>
@@ -48,15 +60,26 @@ export default function VisitedPlaceSearch({ onSelectPlace }: VisitedPlaceSearch
 
   return (
     <>
-      <PlaceSearchInput placeholder="검색어를 입력해주세요" onSearch={setKeyword} />
+      <PlaceSearchInput
+        placeholder="검색어를 입력해주세요"
+        onSearch={setKeyword}
+        appliedKeyword={appliedKeyword}
+      />
+      {!hasKeyword && (
+        <RecentSearchList
+          keywords={recentSearches}
+          onSelect={setAppliedKeyword}
+          onRemove={removeRecentSearch}
+        />
+      )}
       <PlaceSearchResultList
         places={matchedPlaces}
-        hasKeyword={keyword.trim().length > 0}
+        hasKeyword={hasKeyword}
         isLoading={searchQuery.isPending}
         isError={searchQuery.isError && !searchQuery.data}
         emptyMessage="기록한 장소 중에 검색 결과가 없습니다"
         getThumbnailSrc={(place) => place.thumbnailSrc}
-        onSelect={(place) => onSelectPlace(place.id)}
+        onSelect={(place) => handleSelectPlace(place.id)}
       />
       <div ref={loadMoreRef} aria-hidden="true" className="h-1" />
       {isFetchingNextPage && (

--- a/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.tsx
+++ b/apps/web/src/features/shop/components/visited-place-search/VisitedPlaceSearch.tsx
@@ -21,7 +21,7 @@ type VisitedPlaceSearchItem = PlaceSearchItem & {
 /** 소비 기록이 있는 장소만 매장명과 주소로 검색합니다. */
 export default function VisitedPlaceSearch({ onSelectPlace }: VisitedPlaceSearchProps) {
   const [keyword, setKeyword] = useState('');
-  const [appliedKeyword, setAppliedKeyword] = useState<string>();
+  const [appliedKeyword, setAppliedKeyword] = useState<{ keyword: string }>();
   const { addRecentSearch, recentSearches, removeRecentSearch } = useRecentSearches();
   const searchQuery = useVisitedPlaceSearchInfiniteQuery(keyword);
   const { fetchNextPage, hasNextPage, isFetchNextPageError, isFetchingNextPage } = searchQuery;
@@ -68,7 +68,7 @@ export default function VisitedPlaceSearch({ onSelectPlace }: VisitedPlaceSearch
       {!hasKeyword && (
         <RecentSearchList
           keywords={recentSearches}
-          onSelect={setAppliedKeyword}
+          onSelect={(keyword) => setAppliedKeyword({ keyword })}
           onRemove={removeRecentSearch}
         />
       )}

--- a/apps/web/src/features/shop/components/visited-place-search/useRecentSearches.test.ts
+++ b/apps/web/src/features/shop/components/visited-place-search/useRecentSearches.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useRecentSearches } from './useRecentSearches';
+
+describe('useRecentSearches', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('검색어를 추가하면 최신 검색어가 맨 앞에 온다', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addRecentSearch('투썸');
+    });
+    act(() => {
+      result.current.addRecentSearch('카페');
+    });
+
+    expect(result.current.recentSearches).toEqual(['카페', '투썸']);
+  });
+
+  it('이미 있는 검색어를 다시 추가하면 중복 없이 맨 앞으로 옮긴다', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addRecentSearch('투썸');
+      result.current.addRecentSearch('카페');
+      result.current.addRecentSearch('투썸');
+    });
+
+    expect(result.current.recentSearches).toEqual(['투썸', '카페']);
+  });
+
+  it('빈 문자열이나 공백만 있는 검색어는 추가하지 않는다', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addRecentSearch('   ');
+    });
+
+    expect(result.current.recentSearches).toEqual([]);
+  });
+
+  it('최대 개수를 넘으면 가장 오래된 검색어부터 제거한다', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      for (let i = 0; i < 11; i += 1) {
+        result.current.addRecentSearch(`검색어${i}`);
+      }
+    });
+
+    expect(result.current.recentSearches).toHaveLength(10);
+    expect(result.current.recentSearches).not.toContain('검색어0');
+    expect(result.current.recentSearches[0]).toBe('검색어10');
+  });
+
+  it('검색어를 삭제할 수 있다', () => {
+    const { result } = renderHook(() => useRecentSearches());
+
+    act(() => {
+      result.current.addRecentSearch('투썸');
+      result.current.addRecentSearch('카페');
+    });
+    act(() => {
+      result.current.removeRecentSearch('투썸');
+    });
+
+    expect(result.current.recentSearches).toEqual(['카페']);
+  });
+
+  it('localStorage에 저장된 검색어를 초기값으로 불러온다', () => {
+    const { result: firstResult } = renderHook(() => useRecentSearches());
+    act(() => {
+      firstResult.current.addRecentSearch('투썸');
+    });
+
+    const { result: secondResult } = renderHook(() => useRecentSearches());
+
+    expect(secondResult.current.recentSearches).toEqual(['투썸']);
+  });
+});

--- a/apps/web/src/features/shop/components/visited-place-search/useRecentSearches.ts
+++ b/apps/web/src/features/shop/components/visited-place-search/useRecentSearches.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+
+const RECENT_SEARCH_STORAGE_KEY = 'chapchap:visited-place-recent-searches';
+const RECENT_SEARCH_MAX_COUNT = 10;
+
+const readRecentSearches = (): string[] => {
+  try {
+    const raw = window.localStorage.getItem(RECENT_SEARCH_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeRecentSearches = (searches: string[]) => {
+  try {
+    window.localStorage.setItem(RECENT_SEARCH_STORAGE_KEY, JSON.stringify(searches));
+  } catch {
+    // 프라이빗 모드 등 localStorage를 쓸 수 없는 환경에서는 저장을 건너뛴다
+  }
+};
+
+/** 소비한 곳 검색 화면의 최근 검색어를 localStorage에 저장하고 관리합니다. */
+export const useRecentSearches = () => {
+  const [recentSearches, setRecentSearches] = useState<string[]>(readRecentSearches);
+
+  const addRecentSearch = useCallback((keyword: string) => {
+    const trimmedKeyword = keyword.trim();
+    if (!trimmedKeyword) {
+      return;
+    }
+
+    setRecentSearches((prev) => {
+      const next = [trimmedKeyword, ...prev.filter((item) => item !== trimmedKeyword)].slice(
+        0,
+        RECENT_SEARCH_MAX_COUNT
+      );
+      writeRecentSearches(next);
+      return next;
+    });
+  }, []);
+
+  const removeRecentSearch = useCallback((keyword: string) => {
+    setRecentSearches((prev) => {
+      const next = prev.filter((item) => item !== keyword);
+      writeRecentSearches(next);
+      return next;
+    });
+  }, []);
+
+  return { addRecentSearch, recentSearches, removeRecentSearch };
+};

--- a/apps/web/src/shared/ui/place-search/PlaceSearchInput.test.tsx
+++ b/apps/web/src/shared/ui/place-search/PlaceSearchInput.test.tsx
@@ -42,4 +42,24 @@ describe('PlaceSearchInput', () => {
     });
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
+
+  it('appliedKeyword가 바뀌면 검색어를 채우고 즉시 검색을 실행한다', () => {
+    const onSearch = jest.fn();
+    const { rerender } = render(<PlaceSearchInput onSearch={onSearch} />);
+
+    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+
+    expect(screen.getByPlaceholderText('장소를 검색해주세요')).toHaveValue('투썸');
+    expect(onSearch).toHaveBeenCalledWith('투썸');
+  });
+
+  it('appliedKeyword가 같은 값으로 유지되면 다시 검색하지 않는다', () => {
+    const onSearch = jest.fn();
+    const { rerender } = render(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+    onSearch.mockClear();
+
+    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/shared/ui/place-search/PlaceSearchInput.test.tsx
+++ b/apps/web/src/shared/ui/place-search/PlaceSearchInput.test.tsx
@@ -47,19 +47,35 @@ describe('PlaceSearchInput', () => {
     const onSearch = jest.fn();
     const { rerender } = render(<PlaceSearchInput onSearch={onSearch} />);
 
-    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword={{ keyword: '투썸' }} />);
 
     expect(screen.getByPlaceholderText('장소를 검색해주세요')).toHaveValue('투썸');
     expect(onSearch).toHaveBeenCalledWith('투썸');
   });
 
-  it('appliedKeyword가 같은 값으로 유지되면 다시 검색하지 않는다', () => {
+  it('appliedKeyword 참조가 그대로 유지되면 다시 검색하지 않는다', () => {
     const onSearch = jest.fn();
-    const { rerender } = render(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+    const appliedKeyword = { keyword: '투썸' };
+    const { rerender } = render(
+      <PlaceSearchInput onSearch={onSearch} appliedKeyword={appliedKeyword} />
+    );
     onSearch.mockClear();
 
-    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword="투썸" />);
+    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword={appliedKeyword} />);
 
     expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('같은 검색어를 다시 선택해도(새 객체로 전달되면) 다시 검색한다', () => {
+    const onSearch = jest.fn();
+    const { rerender } = render(
+      <PlaceSearchInput onSearch={onSearch} appliedKeyword={{ keyword: '투썸' }} />
+    );
+    onSearch.mockClear();
+
+    rerender(<PlaceSearchInput onSearch={onSearch} appliedKeyword={{ keyword: '투썸' }} />);
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('투썸');
   });
 });

--- a/apps/web/src/shared/ui/place-search/PlaceSearchInput.tsx
+++ b/apps/web/src/shared/ui/place-search/PlaceSearchInput.tsx
@@ -8,6 +8,8 @@ import type { FormEvent } from 'react';
 const DEFAULT_SEARCH_DEBOUNCE_MS = 400;
 
 type PlaceSearchInputProps = {
+  /** 최근 검색어 선택처럼 외부에서 검색어를 채우고 즉시 검색을 실행할 때 전달합니다. */
+  appliedKeyword?: string;
   debounceMs?: number;
   onSearch: (keyword: string) => void;
   placeholder?: string;
@@ -15,6 +17,7 @@ type PlaceSearchInputProps = {
 
 /** 입력 중 자동 검색과 즉시 제출을 함께 제공하는 공통 장소 검색창입니다. */
 export function PlaceSearchInput({
+  appliedKeyword,
   debounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
   onSearch,
   placeholder = '장소를 검색해주세요',
@@ -23,6 +26,7 @@ export function PlaceSearchInput({
   const debouncedKeyword = useDebouncedValue(keyword, debounceMs);
   const onSearchRef = useRef(onSearch);
   const lastSearchedKeywordRef = useRef(debouncedKeyword);
+  const lastAppliedKeywordRef = useRef(appliedKeyword);
 
   useEffect(() => {
     onSearchRef.current = onSearch;
@@ -36,6 +40,17 @@ export function PlaceSearchInput({
     lastSearchedKeywordRef.current = debouncedKeyword;
     onSearchRef.current(debouncedKeyword);
   }, [debouncedKeyword]);
+
+  useEffect(() => {
+    if (appliedKeyword === undefined || appliedKeyword === lastAppliedKeywordRef.current) {
+      return;
+    }
+
+    lastAppliedKeywordRef.current = appliedKeyword;
+    lastSearchedKeywordRef.current = appliedKeyword;
+    setKeyword(appliedKeyword);
+    onSearchRef.current(appliedKeyword);
+  }, [appliedKeyword]);
 
   const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/apps/web/src/shared/ui/place-search/PlaceSearchInput.tsx
+++ b/apps/web/src/shared/ui/place-search/PlaceSearchInput.tsx
@@ -7,9 +7,16 @@ import type { FormEvent } from 'react';
 
 const DEFAULT_SEARCH_DEBOUNCE_MS = 400;
 
+type AppliedKeyword = {
+  keyword: string;
+};
+
 type PlaceSearchInputProps = {
-  /** 최근 검색어 선택처럼 외부에서 검색어를 채우고 즉시 검색을 실행할 때 전달합니다. */
-  appliedKeyword?: string;
+  /**
+   * 최근 검색어 선택처럼 외부에서 검색어를 채우고 즉시 검색을 실행할 때 전달합니다.
+   * 같은 검색어를 다시 선택해도 반응하도록, 선택할 때마다 새 객체를 전달해야 합니다.
+   */
+  appliedKeyword?: AppliedKeyword;
   debounceMs?: number;
   onSearch: (keyword: string) => void;
   placeholder?: string;
@@ -47,9 +54,9 @@ export function PlaceSearchInput({
     }
 
     lastAppliedKeywordRef.current = appliedKeyword;
-    lastSearchedKeywordRef.current = appliedKeyword;
-    setKeyword(appliedKeyword);
-    onSearchRef.current(appliedKeyword);
+    lastSearchedKeywordRef.current = appliedKeyword.keyword;
+    setKeyword(appliedKeyword.keyword);
+    onSearchRef.current(appliedKeyword.keyword);
   }, [appliedKeyword]);
 
   const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #133

## ✅ 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### 최근 검색어 저장 훅

- `useRecentSearches` 훅 추가: localStorage 기반으로 최근 검색어 추가·삭제·중복 제거(최대 10개) 관리

### 최근 검색어 칩 목록 컴포넌트

- `RecentSearchList` 컴포넌트 추가: 검색어 미입력 상태에서 최근 검색어를 칩으로 표시, 칩별 삭제(X) 버튼 제공

### PlaceSearchInput 외부 검색어 적용 기능

- `appliedKeyword` prop 추가: 최근 검색어 칩을 클릭했을 때 검색창에 해당 검색어를 채우고 즉시 검색을 실행 (기존 `onSearch`/디바운스 동작에는 영향 없음)

### 소비한 곳 검색 화면 연동

- `VisitedPlaceSearch`에 최근 검색어 기능 연동: 검색 결과에서 매장을 **선택했을 때만** 검색어를 최근 검색어로 저장 (타이핑 중 디바운스만으로는 저장하지 않음)

### 📸 스크린샷

<img width="1018" height="1444" alt="image" src="https://github.com/user-attachments/assets/cb5e6832-efcc-4751-8884-66bde5c96642" />

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 최근 검색어 저장 시점을 "매장 선택 시"로 정했는데, 이 기준이 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 최근 검색어를 최대 10개까지 저장하고 관리합니다.
  * 검색 화면에서 최근 검색어를 다시 선택하거나 개별 삭제할 수 있습니다.
  * 최근 검색어를 선택하면 입력값이 자동으로 적용되고 즉시 검색됩니다.

* **테스트**
  * 최근 검색어 저장, 중복 제거, 삭제 및 복원 동작을 검증했습니다.
  * 최근 검색어 선택과 검색 입력 동작에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->