### PR TITLE
🐛 [Fix/#138] 월간 리포트 Empty 카드 스타일 수정

### DIFF
--- a/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.test.tsx
+++ b/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.test.tsx
@@ -1,14 +1,25 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import MonthlyReportUnavailableCard from './MonthlyReportUnavailableCard';
 
 describe('MonthlyReportUnavailableCard', () => {
-  it('선택한 월을 회전 기능이 없는 물음표 카드로 표시한다', () => {
-    render(<MonthlyReportUnavailableCard selectedMonth={{ month: 6, year: 2026 }} />);
+  it('카드가 없는 월을 최신 리포트 이동 버튼과 함께 표시한다', async () => {
+    const onViewCurrentReport = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MonthlyReportUnavailableCard
+        onViewCurrentReport={onViewCurrentReport}
+        selectedMonth={{ month: 6, year: 2026 }}
+      />
+    );
 
     expect(screen.getByRole('article', { name: '6월 리포트 미생성 카드' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '6월 리포트가 없어요' })).toBeInTheDocument();
-    expect(screen.getByText('다음 달 리포트를 위해 기록해 주세요')).toBeInTheDocument();
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '생성된 카드가 없어요' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '이번달 리포트 보러가기' }));
+
+    expect(onViewCurrentReport).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.tsx
+++ b/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.tsx
@@ -30,8 +30,8 @@ export default function MonthlyReportUnavailableCard({
         <h2 className="break-keep text-title-02-semibold">생성된 카드가 없어요</h2>
         <button
           className="mt-2 inline-flex items-center gap-1 text-body-02-medium outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2"
+          disabled={!isActionAvailable}
           onClick={onViewCurrentReport}
-          tabIndex={isActionAvailable ? 0 : -1}
           type="button"
         >
           이번달 리포트 보러가기

--- a/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.tsx
+++ b/apps/web/src/features/report/components/monthly-report/MonthlyReportUnavailableCard.tsx
@@ -1,39 +1,42 @@
+import { ChevronRightIcon } from '@/shared/assets/icons';
 import { ReportCardTextureImage } from '@/shared/assets/images/preference-card';
 import type { YearMonth } from '@/shared/types/yearMonth';
 
 type MonthlyReportUnavailableCardProps = {
+  isActionAvailable?: boolean;
+  onViewCurrentReport: () => void;
   selectedMonth: YearMonth;
 };
 
-/** 리포트가 생성되지 않은 월을 물음표 카드로 표시합니다. */
+/** 카드가 생성되지 않은 월을 최신 월간 리포트로 이동할 수 있는 카드로 표시합니다. */
 export default function MonthlyReportUnavailableCard({
+  isActionAvailable = true,
+  onViewCurrentReport,
   selectedMonth,
 }: MonthlyReportUnavailableCardProps) {
   return (
     <article
       aria-label={`${selectedMonth.month}월 리포트 미생성 카드`}
-      className="relative h-93.75 w-69 overflow-hidden rounded-15 bg-primary-300 shadow-report-preference-card"
+      className="relative h-93.75 w-69 overflow-hidden rounded-15 bg-neutral-400 shadow-report-preference-card"
     >
       <img
         alt=""
         aria-hidden
-        className="pointer-events-none absolute inset-0 size-full object-cover opacity-25 mix-blend-overlay select-none"
+        className="pointer-events-none absolute inset-0 size-full object-cover opacity-25 select-none"
         draggable={false}
         src={ReportCardTextureImage}
       />
-      <span
-        aria-hidden
-        className="absolute inset-0 flex items-center justify-center text-[132px] leading-none font-bold text-primary-500"
-      >
-        ?
-      </span>
-      <div className="absolute inset-x-5 bottom-8 text-center">
-        <h2 className="break-keep text-title-02-semibold text-neutral-00">
-          {selectedMonth.month}월 리포트가 없어요
-        </h2>
-        <p className="mt-2 break-keep text-body-02-semibold text-primary-100">
-          다음 달 리포트를 위해 기록해 주세요
-        </p>
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center text-neutral-500">
+        <h2 className="break-keep text-title-02-semibold">생성된 카드가 없어요</h2>
+        <button
+          className="mt-2 inline-flex items-center gap-1 text-body-02-medium outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2"
+          onClick={onViewCurrentReport}
+          tabIndex={isActionAvailable ? 0 : -1}
+          type="button"
+        >
+          이번달 리포트 보러가기
+          <ChevronRightIcon aria-hidden className="size-4" />
+        </button>
       </div>
     </article>
   );

--- a/apps/web/src/features/report/components/monthly-report/ReportPreferenceSection.test.tsx
+++ b/apps/web/src/features/report/components/monthly-report/ReportPreferenceSection.test.tsx
@@ -28,6 +28,7 @@ describe('ReportPreferenceSection', () => {
         onCardTransitionChange={jest.fn()}
         onFlip={jest.fn()}
         onShare={jest.fn()}
+        onViewCurrentReport={jest.fn()}
         selectedCardIndex={0}
         thumbnailCaptureRef={thumbnailCaptureRef}
       />
@@ -46,7 +47,7 @@ describe('ReportPreferenceSection', () => {
     ).toBeNull();
   });
 
-  it('내부 버튼이 없는 empty 카드에서도 캐러셀에 포커스해 키보드로 이동한다', () => {
+  it('empty 카드에서는 공유와 뒤집기 버튼을 비활성화하고 키보드 월 이동은 유지한다', () => {
     const onCardSelect = jest.fn();
 
     render(
@@ -69,6 +70,7 @@ describe('ReportPreferenceSection', () => {
         onCardTransitionChange={jest.fn()}
         onFlip={jest.fn()}
         onShare={jest.fn()}
+        onViewCurrentReport={jest.fn()}
         selectedCardIndex={0}
         thumbnailCaptureRef={createRef<HTMLDivElement>()}
       />
@@ -77,6 +79,13 @@ describe('ReportPreferenceSection', () => {
     const carousel = screen.getByRole('region', { name: '월별 소비 성향 카드' });
 
     expect(carousel).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('button', { name: '취향 카드 공유하기' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '취향 카드 뒤집기' })).toBeDisabled();
+    expect(screen.getByText('해당 월에 생성된 리포트가 없어요')).toHaveClass(
+      'mt-30',
+      'text-title-02-semibold',
+      'text-neutral-400'
+    );
 
     carousel.focus();
     fireEvent.keyDown(carousel, { key: 'ArrowRight' });

--- a/apps/web/src/features/report/components/monthly-report/ReportPreferenceSection.tsx
+++ b/apps/web/src/features/report/components/monthly-report/ReportPreferenceSection.tsx
@@ -20,6 +20,7 @@ type ReportPreferenceSectionProps = {
   onCardTransitionChange: (isTransitioning: boolean) => void;
   onFlip: () => void;
   onShare: () => void;
+  onViewCurrentReport: () => void;
   selectedCardIndex: number;
   thumbnailCaptureRef: Ref<HTMLDivElement>;
 };
@@ -33,6 +34,7 @@ export default function ReportPreferenceSection({
   onCardTransitionChange,
   onFlip,
   onShare,
+  onViewCurrentReport,
   selectedCardIndex,
   thumbnailCaptureRef,
 }: ReportPreferenceSectionProps) {
@@ -93,7 +95,11 @@ export default function ReportPreferenceSection({
               key={card.id}
             >
               {card.isUnavailable ? (
-                <MonthlyReportUnavailableCard selectedMonth={card.month} />
+                <MonthlyReportUnavailableCard
+                  isActionAvailable={isSelected}
+                  onViewCurrentReport={onViewCurrentReport}
+                  selectedMonth={card.month}
+                />
               ) : (
                 <ReportPreferenceCard
                   description={card.description}
@@ -132,25 +138,32 @@ export default function ReportPreferenceSection({
               />
             </div>
           </div>
-          <div className="mt-6.25 flex items-center gap-3.75">
-            <button
-              className="flex h-9.25 items-center gap-2 rounded-full bg-neutral-200 px-5 text-body-02-medium text-neutral-700"
-              onClick={onShare}
-              type="button"
-            >
-              <ShareIcon aria-hidden className="size-4" />
-              취향 카드 공유하기
-            </button>
-            <button
-              aria-label="취향 카드 뒤집기"
-              className="flex size-10 items-center justify-center rounded-full bg-neutral-200 text-lg text-neutral-600"
-              onClick={onFlip}
-              type="button"
-            >
-              <ReportCardFlipIcon aria-hidden className="h-3.25 w-3" />
-            </button>
-          </div>
         </>
+      )}
+      <div className="mt-6.25 flex items-center gap-3.75">
+        <button
+          className="flex h-9.25 items-center gap-2 rounded-full bg-neutral-200 px-5 text-body-02-medium text-neutral-700 disabled:cursor-not-allowed disabled:bg-neutral-200 disabled:text-neutral-400"
+          disabled={selectedCard.isUnavailable}
+          onClick={onShare}
+          type="button"
+        >
+          <ShareIcon aria-hidden className="size-4" />
+          취향 카드 공유하기
+        </button>
+        <button
+          aria-label="취향 카드 뒤집기"
+          className="flex size-10 items-center justify-center rounded-full bg-neutral-200 text-lg text-neutral-600 disabled:cursor-not-allowed disabled:bg-neutral-200 disabled:text-neutral-400 disabled:[&_path]:fill-neutral-200 disabled:[&_path]:stroke-neutral-400"
+          disabled={selectedCard.isUnavailable}
+          onClick={onFlip}
+          type="button"
+        >
+          <ReportCardFlipIcon aria-hidden className="h-3.25 w-3" />
+        </button>
+      </div>
+      {selectedCard.isUnavailable && (
+        <p className="mt-30 text-center text-title-02-semibold text-neutral-400">
+          해당 월에 생성된 리포트가 없어요
+        </p>
       )}
     </section>
   );

--- a/apps/web/src/features/report/hooks/useMonthlyReport.test.tsx
+++ b/apps/web/src/features/report/hooks/useMonthlyReport.test.tsx
@@ -47,6 +47,7 @@ jest.mock('./useReportImageDownload', () => ({
 
 function MonthlyReportHarness() {
   const {
+    handleCurrentReportSelect,
     handleMonthPickerOpen,
     handleMonthSelect,
     handleNewerMonth,
@@ -77,6 +78,9 @@ function MonthlyReportHarness() {
       </button>
       <button onClick={handleNewerMonth} type="button">
         다음 달
+      </button>
+      <button onClick={handleCurrentReportSelect} type="button">
+        이번달 리포트
       </button>
       <button onClick={() => navigate(-1)} type="button">
         브라우저 뒤로가기
@@ -144,6 +148,16 @@ describe('useMonthlyReport', () => {
 
     expect(screen.getByText('2026-6')).toBeInTheDocument();
     expect(screen.getByText('?yearMonth=2026-06')).toBeInTheDocument();
+  });
+
+  it('이번달 리포트 선택 시 최신 리포트 월로 이동한다', async () => {
+    const user = userEvent.setup();
+    renderMonthlyReportHook('/report/monthly-report?yearMonth=2026-05');
+
+    await user.click(screen.getByRole('button', { name: '이번달 리포트' }));
+
+    expect(screen.getByText('2026-7')).toBeInTheDocument();
+    expect(screen.getByText('?yearMonth=2026-07')).toBeInTheDocument();
   });
 
   it('월 선택 시트를 열고 선택한 리포트 월을 URL에 반영한다', async () => {

--- a/apps/web/src/features/report/hooks/useMonthlyReport.ts
+++ b/apps/web/src/features/report/hooks/useMonthlyReport.ts
@@ -114,6 +114,8 @@ export const useMonthlyReport = () => {
     setIsMonthPickerOpen(false);
   };
 
+  const handleCurrentReportSelect = () => handleMonthChange(selectableMonths[0]);
+
   const handleReportCardSelect = (index: number) => {
     const reportCard = reportCards[index];
 
@@ -136,6 +138,7 @@ export const useMonthlyReport = () => {
     captureRef,
     downloadImage,
     handleCardTransitionChange,
+    handleCurrentReportSelect,
     handleNewerMonth,
     handleOlderMonth,
     handleMonthPickerClose,

--- a/apps/web/src/pages/report/MonthlyReportPage.tsx
+++ b/apps/web/src/pages/report/MonthlyReportPage.tsx
@@ -28,6 +28,7 @@ export default function MonthlyReportPage() {
     captureRef,
     downloadImage,
     handleCardTransitionChange,
+    handleCurrentReportSelect,
     handleNewerMonth,
     handleOlderMonth,
     handleMonthPickerClose,
@@ -111,6 +112,7 @@ export default function MonthlyReportPage() {
             onCardTransitionChange={handleCardTransitionChange}
             onFlip={handlePreferenceCardFlip}
             onShare={handleShareSheetOpen}
+            onViewCurrentReport={handleCurrentReportSelect}
             selectedCardIndex={selectedCardIndex}
             thumbnailCaptureRef={kakaoThumbnailRef}
           />
@@ -118,7 +120,10 @@ export default function MonthlyReportPage() {
         {!isPending && !report && (
           <div className="mt-4.5 flex flex-col items-center">
             {reportCards.length === 0 && (
-              <MonthlyReportUnavailableCard selectedMonth={selectedMonth} />
+              <MonthlyReportUnavailableCard
+                onViewCurrentReport={handleCurrentReportSelect}
+                selectedMonth={selectedMonth}
+              />
             )}
             <MonthlyReportEmptyState selectedMonth={selectedMonth} />
           </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #138

## ✅ 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

- 변경된 디자인 시안으로 월간 리포트 Empty 카드 스타일을 수정했습니다.

### 📸 스크린샷

### 📦 추가한 라이브러리

### 💬 리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 월간 리포트가 없는 달에도 현재 이용 가능한 최신 리포트로 바로 이동할 수 있는 버튼을 제공합니다.
  - 리포트가 생성되지 않은 경우 해당 상태를 안내하는 카드가 표시됩니다.

- **개선 사항**
  - 리포트가 없는 달에는 공유 및 카드 뒤집기 기능이 비활성화됩니다.
  - 월 이동과 현재 리포트로 이동하는 흐름이 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->