### PR TITLE
✨ [Feat/#142] 인증 콜백 상태별 안내 및 이동 처리

### DIFF
--- a/apps/web/src/features/auth/apis/hooks/useSocialLoginCallback.test.tsx
+++ b/apps/web/src/features/auth/apis/hooks/useSocialLoginCallback.test.tsx
@@ -1,28 +1,37 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import type { ApiResponseAuthenticationResponse } from '@/features/auth/apis/dto';
 import { useExchangeSocialLoginCode } from '@/features/auth/apis/mutations';
+import { reloadToAuthPath } from '@/features/auth/utils/authCallbackNavigation';
 import { saveCodeVerifier } from '@/features/auth/utils/oauthSession';
 import { clearNativeRefreshToken, setNativeRefreshToken } from '@/shared/apis/nativeAuthToken';
 import { isNativeApp } from '@/shared/lib/bridge';
 import { useAuthStore } from '@/shared/stores/authStore';
+import { useToast } from '@/shared/ui/toast';
 
 import { useSocialLoginCallback } from './useSocialLoginCallback';
 
 jest.mock('@/features/auth/apis/mutations', () => ({
   useExchangeSocialLoginCode: jest.fn(),
 }));
+jest.mock('@tanstack/react-query', () => ({ useQueryClient: jest.fn() }));
+jest.mock('@/features/auth/utils/authCallbackNavigation', () => ({ reloadToAuthPath: jest.fn() }));
 jest.mock('@/shared/apis/nativeAuthToken', () => ({
   clearNativeRefreshToken: jest.fn(),
   setNativeRefreshToken: jest.fn(),
 }));
 jest.mock('@/shared/lib/bridge', () => ({ isNativeApp: jest.fn() }));
+jest.mock('@/shared/ui/toast', () => ({ useToast: jest.fn() }));
 
 const mockUseExchangeSocialLoginCode = jest.mocked(useExchangeSocialLoginCode);
 const mockClearNativeRefreshToken = jest.mocked(clearNativeRefreshToken);
 const mockSetNativeRefreshToken = jest.mocked(setNativeRefreshToken);
 const mockIsNativeApp = jest.mocked(isNativeApp);
+const mockReloadToAuthPath = jest.mocked(reloadToAuthPath);
+const mockClearQueries = jest.fn();
+const mockShowToast = jest.fn();
 const mockMutate = jest.fn();
 let handleSuccess:
   ((response: ApiResponseAuthenticationResponse) => void | Promise<void>) | undefined;
@@ -42,6 +51,7 @@ const renderCallback = (initialEntry: string) =>
         <Route path="/auth/callback" element={<CallbackHarness />} />
         <Route path="/agreement" element={<p>약관 동의 화면</p>} />
         <Route path="/home" element={<p>홈 화면</p>} />
+        <Route path="/" element={<p>로그인 화면</p>} />
       </Routes>
     </MemoryRouter>
   );
@@ -54,6 +64,11 @@ describe('useSocialLoginCallback', () => {
     mockIsNativeApp.mockReturnValue(false);
     mockClearNativeRefreshToken.mockResolvedValue();
     mockSetNativeRefreshToken.mockResolvedValue();
+    jest.mocked(useQueryClient).mockReturnValue({ clear: mockClearQueries } as never);
+    jest.mocked(useToast).mockReturnValue({
+      showToast: mockShowToast,
+      closeToast: jest.fn(),
+    });
     useAuthStore.setState({
       accessToken: null,
       signupToken: null,
@@ -161,12 +176,33 @@ describe('useSocialLoginCallback', () => {
     });
   });
 
-  it('OAuth 취소 query가 전달되면 교환하지 않고 오류를 표시한다', async () => {
+  it('OAuth 취소 query가 전달되면 교환하지 않고 로그인 화면으로 돌아간다', async () => {
     saveCodeVerifier('code-verifier');
 
-    renderCallback('/auth/callback?error=access_denied');
+    renderCallback('/auth/callback?error=oauth_cancelled');
 
-    expect(await screen.findByText('소셜 로그인이 취소되었습니다.')).toBeInTheDocument();
+    expect(await screen.findByText('로그인 화면')).toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('회원 탈퇴 취소 query가 전달되면 인증을 복원할 수 있도록 마이페이지를 다시 연다', async () => {
+    renderCallback('/auth/callback?error=withdrawal_cancelled');
+
+    await waitFor(() => expect(mockReloadToAuthPath).toHaveBeenCalledWith('/my-page'));
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it('회원 탈퇴 성공 query가 전달되면 인증과 캐시를 정리하고 완료를 안내한다', async () => {
+    useAuthStore.getState().setAccessToken('access-token');
+    renderCallback('/auth/callback?withdrawal=success');
+
+    await waitFor(() => expect(useAuthStore.getState().accessToken).toBeNull());
+    expect(mockClearQueries).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith({
+      type: 'success',
+      message: '회원 탈퇴가 완료되었습니다.',
+    });
+    expect(await screen.findByText('로그인 화면')).toBeInTheDocument();
     expect(mockMutate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/auth/apis/hooks/useSocialLoginCallback.ts
+++ b/apps/web/src/features/auth/apis/hooks/useSocialLoginCallback.ts
@@ -1,9 +1,11 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useExchangeSocialLoginCode } from '@/features/auth/apis/mutations';
 import { AUTH_FLOW_ERROR_CODE, AuthFlowError } from '@/features/auth/errors';
-import { consumeOAuthCallback } from '@/features/auth/utils/oauthSession';
+import { reloadToAuthPath } from '@/features/auth/utils/authCallbackNavigation';
+import { resolveAuthCallback } from '@/features/auth/utils/resolveAuthCallback';
 import { resolveAuthenticationResult } from '@/features/auth/utils/resolveAuthenticationResult';
 import {
   clearAuthenticationTokens,
@@ -11,11 +13,14 @@ import {
 } from '@/shared/apis/authTokenLifecycle';
 import { ROUTE_PATHS } from '@/shared/constants/routePaths';
 import { useAuthStore } from '@/shared/stores/authStore';
+import { useToast } from '@/shared/ui/toast';
 
 /** OAuth 콜백을 한 번만 교환하고 인증 결과에 맞는 화면으로 이동합니다. */
 export const useSocialLoginCallback = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
+  const { showToast } = useToast();
   const hasStarted = useRef(false);
   const [callbackError, setCallbackError] = useState<Error | null>(null);
   const setSignupToken = useAuthStore((state) => state.setSignupToken);
@@ -60,15 +65,35 @@ export const useSocialLoginCallback = () => {
     hasStarted.current = true;
 
     try {
-      const credentials = consumeOAuthCallback(searchParams);
-      mutate({ data: credentials });
+      const result = resolveAuthCallback(searchParams);
+
+      if (result.type === 'oauthCancelled') {
+        navigate(ROUTE_PATHS.login, { replace: true });
+        return;
+      }
+
+      if (result.type === 'withdrawalCancelled') {
+        reloadToAuthPath(ROUTE_PATHS.myPage);
+        return;
+      }
+
+      if (result.type === 'withdrawalSuccess') {
+        void clearAuthenticationTokens().then(() => {
+          queryClient.clear();
+          showToast({ type: 'success', message: '회원 탈퇴가 완료되었습니다.' });
+          navigate(ROUTE_PATHS.login, { replace: true });
+        });
+        return;
+      }
+
+      mutate({ data: result.credentials });
     } catch (error) {
       const callbackProcessingError =
         error instanceof Error ? error : new Error('로그인 콜백을 처리하지 못했습니다.');
 
       queueMicrotask(() => setCallbackError(callbackProcessingError));
     }
-  }, [mutate, searchParams]);
+  }, [mutate, navigate, queryClient, searchParams, showToast]);
 
   return {
     error: callbackError,

--- a/apps/web/src/features/auth/components/social-login-callback/SocialLoginCallback.test.tsx
+++ b/apps/web/src/features/auth/components/social-login-callback/SocialLoginCallback.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useSocialLoginCallback } from '@/features/auth/apis/hooks/useSocialLoginCallback';
+import { AUTH_FLOW_ERROR_CODE, AuthFlowError } from '@/features/auth/errors';
+import type { AuthFlowErrorCode } from '@/features/auth/errors';
+
+import SocialLoginCallback from './SocialLoginCallback';
+
+jest.mock('@/features/auth/apis/hooks/useSocialLoginCallback', () => ({
+  useSocialLoginCallback: jest.fn(),
+}));
+
+const renderError = (code: AuthFlowErrorCode) => {
+  jest.mocked(useSocialLoginCallback).mockReturnValue({
+    error: new AuthFlowError(code),
+    isLoading: false,
+  });
+
+  render(
+    <MemoryRouter>
+      <SocialLoginCallback />
+    </MemoryRouter>
+  );
+};
+
+describe('SocialLoginCallback', () => {
+  it('탈퇴 계정의 데이터 삭제 및 재가입 가능 시점을 안내한다', () => {
+    renderError(AUTH_FLOW_ERROR_CODE.ACCOUNT_WITHDRAWN);
+
+    expect(
+      screen.getByRole('heading', { name: '탈퇴한 계정은 로그인할 수 없어요' })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/계정 데이터는 탈퇴 다음 날 0시에 삭제돼요/)).toHaveTextContent(
+      '계정 데이터는 탈퇴 다음 날 0시에 삭제돼요. 삭제가 완료된 후 다시 가입할 수 있어요.'
+    );
+  });
+
+  it.each([
+    [AUTH_FLOW_ERROR_CODE.OAUTH_FAILED, '소셜 로그인에 실패했어요'],
+    [AUTH_FLOW_ERROR_CODE.WITHDRAWAL_FAILED, '회원 탈퇴에 실패했어요'],
+  ] as const)('%s 오류에 맞는 제목을 표시한다', (code, title) => {
+    renderError(code);
+
+    expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+    expect(screen.getByText('잠시 후 다시 시도해 주세요.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/auth/components/social-login-callback/SocialLoginCallback.tsx
+++ b/apps/web/src/features/auth/components/social-login-callback/SocialLoginCallback.tsx
@@ -1,4 +1,5 @@
 import { useSocialLoginCallback } from '@/features/auth/apis/hooks/useSocialLoginCallback';
+import { AUTH_FLOW_ERROR_CODE, AuthFlowError } from '@/features/auth/errors';
 import { ROUTE_PATHS } from '@/shared/constants/routePaths';
 import { Spinner } from '@/shared/ui/spinner';
 import { StateView } from '@/shared/ui/state-view';
@@ -7,12 +8,14 @@ export default function SocialLoginCallback() {
   const { error, isLoading } = useSocialLoginCallback();
 
   if (error) {
+    const errorContent = getCallbackErrorContent(error);
+
     return (
       <StateView
         variant="error"
         headingAs="h1"
-        title="로그인을 완료하지 못했어요"
-        description={error.message}
+        title={errorContent.title}
+        description={errorContent.description}
         actionLabel="로그인으로 돌아가기"
         to={ROUTE_PATHS.login}
       />
@@ -26,3 +29,34 @@ export default function SocialLoginCallback() {
     </section>
   );
 }
+
+const getCallbackErrorContent = (error: Error) => {
+  if (error instanceof AuthFlowError) {
+    if (error.code === AUTH_FLOW_ERROR_CODE.ACCOUNT_WITHDRAWN) {
+      return {
+        title: '탈퇴한 계정은 로그인할 수 없어요',
+        description:
+          '계정 데이터는 탈퇴 다음 날 0시에 삭제돼요.\n삭제가 완료된 후 다시 가입할 수 있어요.',
+      };
+    }
+
+    if (error.code === AUTH_FLOW_ERROR_CODE.OAUTH_FAILED) {
+      return {
+        title: '소셜 로그인에 실패했어요',
+        description: '잠시 후 다시 시도해 주세요.',
+      };
+    }
+
+    if (error.code === AUTH_FLOW_ERROR_CODE.WITHDRAWAL_FAILED) {
+      return {
+        title: '회원 탈퇴에 실패했어요',
+        description: '잠시 후 다시 시도해 주세요.',
+      };
+    }
+  }
+
+  return {
+    title: '로그인을 완료하지 못했어요',
+    description: error.message,
+  };
+};

--- a/apps/web/src/features/auth/errors.ts
+++ b/apps/web/src/features/auth/errors.ts
@@ -3,6 +3,8 @@ export const AUTH_FLOW_ERROR_CODE = {
   DUPLICATE_CALLBACK: 'duplicateCallback',
   OAUTH_CANCELLED: 'oauthCancelled',
   OAUTH_FAILED: 'oauthFailed',
+  ACCOUNT_WITHDRAWN: 'accountWithdrawn',
+  WITHDRAWAL_FAILED: 'withdrawalFailed',
   MISSING_LOGIN_CODE: 'missingLoginCode',
   INVALID_AUTH_RESPONSE: 'invalidAuthResponse',
 } as const;
@@ -15,6 +17,8 @@ const AUTH_FLOW_ERROR_MESSAGE: Record<AuthFlowErrorCode, string> = {
   [AUTH_FLOW_ERROR_CODE.DUPLICATE_CALLBACK]: '이미 처리된 로그인 요청입니다.',
   [AUTH_FLOW_ERROR_CODE.OAUTH_CANCELLED]: '소셜 로그인이 취소되었습니다.',
   [AUTH_FLOW_ERROR_CODE.OAUTH_FAILED]: '소셜 로그인을 완료하지 못했습니다. 다시 시도해 주세요.',
+  [AUTH_FLOW_ERROR_CODE.ACCOUNT_WITHDRAWN]: '탈퇴한 계정은 로그인할 수 없습니다.',
+  [AUTH_FLOW_ERROR_CODE.WITHDRAWAL_FAILED]: '회원 탈퇴에 실패했습니다.',
   [AUTH_FLOW_ERROR_CODE.MISSING_LOGIN_CODE]: '로그인 코드를 확인할 수 없습니다.',
   [AUTH_FLOW_ERROR_CODE.INVALID_AUTH_RESPONSE]:
     '로그인 결과를 확인할 수 없습니다. 다시 로그인해 주세요.',

--- a/apps/web/src/features/auth/utils/authCallbackNavigation.ts
+++ b/apps/web/src/features/auth/utils/authCallbackNavigation.ts
@@ -1,0 +1,4 @@
+/** 인증 복원이 필요한 경로를 새 문서로 열어 AuthProvider가 다시 실행되게 합니다. */
+export const reloadToAuthPath = (path: string) => {
+  window.location.replace(path);
+};

--- a/apps/web/src/features/auth/utils/resolveAuthCallback.test.ts
+++ b/apps/web/src/features/auth/utils/resolveAuthCallback.test.ts
@@ -1,0 +1,42 @@
+import { AUTH_FLOW_ERROR_CODE } from '@/features/auth/errors';
+import { saveCodeVerifier } from '@/features/auth/utils/oauthSession';
+
+import { resolveAuthCallback } from './resolveAuthCallback';
+
+describe('resolveAuthCallback', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('loginCode는 토큰 교환 정보로 변환한다', () => {
+    saveCodeVerifier('code-verifier');
+
+    expect(resolveAuthCallback(new URLSearchParams({ loginCode: 'login-code' }))).toEqual({
+      type: 'tokenExchange',
+      credentials: { loginCode: 'login-code', codeVerifier: 'code-verifier' },
+    });
+  });
+
+  it.each([
+    ['oauth_cancelled', 'oauthCancelled'],
+    ['withdrawal_cancelled', 'withdrawalCancelled'],
+  ] as const)('%s는 별도 오류 화면 없이 복귀 동작으로 변환한다', (error, type) => {
+    expect(resolveAuthCallback(new URLSearchParams({ error }))).toEqual({ type });
+  });
+
+  it('탈퇴 성공 query를 완료 동작으로 변환한다', () => {
+    expect(resolveAuthCallback(new URLSearchParams({ withdrawal: 'success' }))).toEqual({
+      type: 'withdrawalSuccess',
+    });
+  });
+
+  it.each([
+    ['account_withdrawn', AUTH_FLOW_ERROR_CODE.ACCOUNT_WITHDRAWN],
+    ['oauth_failed', AUTH_FLOW_ERROR_CODE.OAUTH_FAILED],
+    ['withdrawal_failed', AUTH_FLOW_ERROR_CODE.WITHDRAWAL_FAILED],
+  ] as const)('%s를 사용자 안내 오류로 변환한다', (error, code) => {
+    expect(() => resolveAuthCallback(new URLSearchParams({ error }))).toThrow(
+      expect.objectContaining({ code })
+    );
+  });
+});

--- a/apps/web/src/features/auth/utils/resolveAuthCallback.ts
+++ b/apps/web/src/features/auth/utils/resolveAuthCallback.ts
@@ -1,0 +1,47 @@
+import { AUTH_FLOW_ERROR_CODE, AuthFlowError } from '@/features/auth/errors';
+
+import { clearOAuthSession, consumeOAuthCallback } from './oauthSession';
+
+export type AuthCallbackResult =
+  | {
+      type: 'tokenExchange';
+      credentials: ReturnType<typeof consumeOAuthCallback>;
+    }
+  | { type: 'oauthCancelled' }
+  | { type: 'withdrawalSuccess' }
+  | { type: 'withdrawalCancelled' };
+
+/** 로그인과 회원 탈퇴가 공유하는 OAuth 콜백 query를 후속 동작으로 변환합니다. */
+export const resolveAuthCallback = (searchParams: URLSearchParams): AuthCallbackResult => {
+  if (searchParams.get('withdrawal') === 'success') {
+    clearOAuthSession();
+    return { type: 'withdrawalSuccess' };
+  }
+
+  const callbackError = searchParams.get('error');
+
+  if (callbackError === 'oauth_cancelled') {
+    clearOAuthSession();
+    return { type: 'oauthCancelled' };
+  }
+
+  if (callbackError === 'withdrawal_cancelled') {
+    clearOAuthSession();
+    return { type: 'withdrawalCancelled' };
+  }
+
+  if (callbackError === 'account_withdrawn') {
+    clearOAuthSession();
+    throw new AuthFlowError(AUTH_FLOW_ERROR_CODE.ACCOUNT_WITHDRAWN);
+  }
+
+  if (callbackError === 'withdrawal_failed') {
+    clearOAuthSession();
+    throw new AuthFlowError(AUTH_FLOW_ERROR_CODE.WITHDRAWAL_FAILED);
+  }
+
+  return {
+    type: 'tokenExchange',
+    credentials: consumeOAuthCallback(searchParams),
+  };
+};

--- a/apps/web/src/features/my-page/apis/hooks/useWithdrawAccount.test.tsx
+++ b/apps/web/src/features/my-page/apis/hooks/useWithdrawAccount.test.tsx
@@ -1,0 +1,79 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  redirectToAccountWithdrawal,
+  requestAccountWithdrawal,
+} from '@/features/my-page/apis/withdrawAccount';
+import { clearAuthenticationTokens } from '@/shared/apis/authTokenLifecycle';
+import { useToast } from '@/shared/ui/toast';
+
+import { useWithdrawAccount } from './useWithdrawAccount';
+
+jest.mock('@tanstack/react-query', () => ({ useQueryClient: jest.fn() }));
+jest.mock('react-router-dom', () => ({ useNavigate: jest.fn() }));
+jest.mock('@/features/my-page/apis/withdrawAccount', () => ({
+  redirectToAccountWithdrawal: jest.fn(),
+  requestAccountWithdrawal: jest.fn(),
+}));
+jest.mock('@/shared/apis/authTokenLifecycle', () => ({ clearAuthenticationTokens: jest.fn() }));
+jest.mock('@/shared/ui/toast', () => ({ useToast: jest.fn() }));
+
+const mockClearQueries = jest.fn();
+const mockNavigate = jest.fn();
+const mockShowToast = jest.fn();
+const mockRequestAccountWithdrawal = jest.mocked(requestAccountWithdrawal);
+const mockRedirectToAccountWithdrawal = jest.mocked(redirectToAccountWithdrawal);
+const mockClearAuthenticationTokens = jest.mocked(clearAuthenticationTokens);
+
+describe('useWithdrawAccount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useQueryClient).mockReturnValue({ clear: mockClearQueries } as never);
+    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
+    jest.mocked(useToast).mockReturnValue({ showToast: mockShowToast, closeToast: jest.fn() });
+    mockClearAuthenticationTokens.mockResolvedValue();
+  });
+
+  it('즉시 탈퇴가 완료되면 인증과 캐시를 정리하고 로그인 화면으로 이동한다', async () => {
+    mockRequestAccountWithdrawal.mockResolvedValue({ type: 'completed' });
+    const { result } = renderHook(() => useWithdrawAccount());
+
+    await act(() => result.current.withdraw());
+
+    expect(mockClearAuthenticationTokens).toHaveBeenCalledTimes(1);
+    expect(mockClearQueries).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('재인증이 필요하면 토큰을 지우지 않고 Location 주소로 이동한다', async () => {
+    mockRequestAccountWithdrawal.mockResolvedValue({
+      type: 'reauthentication-required',
+      location: 'https://accounts.google.com/reauthenticate',
+    });
+    const { result } = renderHook(() => useWithdrawAccount());
+
+    await act(() => result.current.withdraw());
+
+    expect(mockRedirectToAccountWithdrawal).toHaveBeenCalledWith(
+      'https://accounts.google.com/reauthenticate'
+    );
+    expect(mockClearAuthenticationTokens).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('탈퇴 요청에 실패하면 오류를 안내한다', async () => {
+    mockRequestAccountWithdrawal.mockRejectedValue(new Error('Withdrawal failed'));
+    const { result } = renderHook(() => useWithdrawAccount());
+
+    await act(() => result.current.withdraw());
+
+    expect(mockShowToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: '회원탈퇴를 완료하지 못했습니다. 다시 시도해 주세요.',
+    });
+    expect(mockClearAuthenticationTokens).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/my-page/apis/hooks/useWithdrawAccount.ts
+++ b/apps/web/src/features/my-page/apis/hooks/useWithdrawAccount.ts
@@ -1,0 +1,44 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  redirectToAccountWithdrawal,
+  requestAccountWithdrawal,
+} from '@/features/my-page/apis/withdrawAccount';
+import { clearAuthenticationTokens } from '@/shared/apis/authTokenLifecycle';
+import { ROUTE_PATHS } from '@/shared/constants/routePaths';
+import { useToast } from '@/shared/ui/toast';
+
+const WITHDRAWAL_ERROR_MESSAGE = '회원탈퇴를 완료하지 못했습니다. 다시 시도해 주세요.';
+
+/** 회원 탈퇴를 요청하고 제공자별 후속 인증 또는 로컬 인증 정보 정리를 처리합니다. */
+export const useWithdrawAccount = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const withdraw = async () => {
+    setIsLoading(true);
+
+    try {
+      const result = await requestAccountWithdrawal();
+
+      if (result.type === 'reauthentication-required') {
+        redirectToAccountWithdrawal(result.location);
+        return;
+      }
+
+      await clearAuthenticationTokens();
+      queryClient.clear();
+      navigate(ROUTE_PATHS.login, { replace: true });
+    } catch {
+      showToast({ type: 'error', message: WITHDRAWAL_ERROR_MESSAGE });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, withdraw };
+};

--- a/apps/web/src/features/my-page/apis/withdrawAccount.test.ts
+++ b/apps/web/src/features/my-page/apis/withdrawAccount.test.ts
@@ -1,0 +1,42 @@
+import { axiosInstance } from '@/shared/apis';
+
+import { requestAccountWithdrawal } from './withdrawAccount';
+
+jest.mock('@/shared/apis', () => ({
+  axiosInstance: { delete: jest.fn() },
+}));
+
+const mockDelete = jest.mocked(axiosInstance.delete);
+
+describe('requestAccountWithdrawal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('즉시 탈퇴 응답이면 완료 결과를 반환한다', async () => {
+    mockDelete.mockResolvedValue({ status: 200, headers: {} } as never);
+
+    await expect(requestAccountWithdrawal()).resolves.toEqual({ type: 'completed' });
+    expect(mockDelete).toHaveBeenCalledWith('/accounts/me');
+  });
+
+  it('재인증이 필요하면 Location 헤더를 반환한다', async () => {
+    mockDelete.mockResolvedValue({
+      status: 202,
+      headers: { location: 'https://accounts.google.com/reauthenticate' },
+    } as never);
+
+    await expect(requestAccountWithdrawal()).resolves.toEqual({
+      type: 'reauthentication-required',
+      location: 'https://accounts.google.com/reauthenticate',
+    });
+  });
+
+  it('202 응답에 Location 헤더가 없으면 실패한다', async () => {
+    mockDelete.mockResolvedValue({ status: 202, headers: {} } as never);
+
+    await expect(requestAccountWithdrawal()).rejects.toThrow(
+      '회원 탈퇴 재인증 주소가 응답에 없습니다.'
+    );
+  });
+});

--- a/apps/web/src/features/my-page/apis/withdrawAccount.ts
+++ b/apps/web/src/features/my-page/apis/withdrawAccount.ts
@@ -1,0 +1,30 @@
+import { axiosInstance } from '@/shared/apis';
+
+import type { ApiResponseVoid } from './dto';
+
+type AccountWithdrawalResult =
+  { type: 'completed' } | { type: 'reauthentication-required'; location: string };
+
+const HTTP_STATUS_ACCEPTED = 202;
+
+/** 응답 상태와 Location 헤더를 보존해 소셜 제공자별 탈퇴 흐름을 구분합니다. */
+export const requestAccountWithdrawal = async (): Promise<AccountWithdrawalResult> => {
+  const response = await axiosInstance.delete<ApiResponseVoid>('/accounts/me');
+
+  if (response.status !== HTTP_STATUS_ACCEPTED) {
+    return { type: 'completed' };
+  }
+
+  const location = response.headers.location;
+
+  if (!location) {
+    throw new Error('회원 탈퇴 재인증 주소가 응답에 없습니다.');
+  }
+
+  return { type: 'reauthentication-required', location };
+};
+
+/** Google 회원 탈퇴에 필요한 재인증 페이지로 현재 창을 이동합니다. */
+export const redirectToAccountWithdrawal = (location: string) => {
+  window.location.assign(location);
+};

--- a/apps/web/src/features/my-page/components/WithdrawAccountButton.test.tsx
+++ b/apps/web/src/features/my-page/components/WithdrawAccountButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useWithdrawAccount } from '@/features/my-page/apis/hooks/useWithdrawAccount';
+
+import WithdrawAccountButton from './WithdrawAccountButton';
+
+jest.mock('@/features/my-page/apis/hooks/useWithdrawAccount', () => ({
+  useWithdrawAccount: jest.fn(),
+}));
+
+const mockWithdraw = jest.fn();
+
+describe('WithdrawAccountButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useWithdrawAccount).mockReturnValue({
+      isLoading: false,
+      withdraw: mockWithdraw,
+    });
+  });
+
+  it('확인 다이얼로그에서 탈퇴를 선택하면 회원 탈퇴를 요청한다', async () => {
+    const user = userEvent.setup();
+    render(<WithdrawAccountButton />);
+
+    await user.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    expect(screen.getByRole('dialog', { name: '정말 탈퇴하시겠어요?' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '탈퇴하기' }));
+
+    expect(mockWithdraw).toHaveBeenCalledTimes(1);
+  });
+
+  it('취소를 선택하면 탈퇴 요청 없이 다이얼로그를 닫는다', async () => {
+    const user = userEvent.setup();
+    render(<WithdrawAccountButton />);
+
+    await user.click(screen.getByRole('button', { name: '회원탈퇴' }));
+    await user.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mockWithdraw).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/my-page/components/WithdrawAccountButton.tsx
+++ b/apps/web/src/features/my-page/components/WithdrawAccountButton.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { useWithdrawAccount } from '@/features/my-page/apis/hooks/useWithdrawAccount';
+import { AccountRemoveIcon } from '@/shared/assets/icons';
+
+import MyPageMenuItem from './MyPageMenuItem';
+import WithdrawAccountDialog from './WithdrawAccountDialog';
+
+export default function WithdrawAccountButton() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { isLoading, withdraw } = useWithdrawAccount();
+
+  return (
+    <>
+      <MyPageMenuItem
+        icon={AccountRemoveIcon}
+        label="회원탈퇴"
+        onClick={() => setIsDialogOpen(true)}
+      />
+
+      {isDialogOpen && (
+        <WithdrawAccountDialog
+          isLoading={isLoading}
+          onCancel={() => setIsDialogOpen(false)}
+          onConfirm={() => void withdraw()}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/my-page/components/WithdrawAccountDialog.tsx
+++ b/apps/web/src/features/my-page/components/WithdrawAccountDialog.tsx
@@ -1,0 +1,72 @@
+import { useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { useScrollLock } from '@/shared/hooks/useScrollLock';
+import { Button } from '@/shared/ui/button';
+
+type WithdrawAccountDialogProps = {
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export default function WithdrawAccountDialog({
+  isLoading,
+  onCancel,
+  onConfirm,
+}: WithdrawAccountDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(dialogRef, {
+    initialFocusSelector: '[data-action="cancel"]',
+    onEscape: isLoading ? undefined : onCancel,
+  });
+  useScrollLock();
+
+  return createPortal(
+    <div className="mobile-frame fixed inset-0 z-dialog flex items-center justify-center bg-neutral-900/30 px-4">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="withdraw-account-title"
+        aria-describedby="withdraw-account-description"
+        className="w-full max-w-[361px] rounded-30 bg-neutral-00 px-4 pt-8 pb-4"
+      >
+        <h2 id="withdraw-account-title" className="text-center text-title-01-bold text-neutral-700">
+          정말 탈퇴하시겠어요?
+        </h2>
+        <p
+          id="withdraw-account-description"
+          className="mt-2 text-center text-body-01-regular text-neutral-500"
+        >
+          탈퇴하면 모든 기록과 계정 정보를 복구할 수 없어요.
+        </p>
+
+        <div className="mt-8 flex gap-3">
+          <Button
+            data-action="cancel"
+            variant="secondary"
+            size="medium"
+            disabled={isLoading}
+            onClick={onCancel}
+            className="h-12 w-0 min-w-0 flex-1 rounded-full border-0 bg-neutral-300 text-body-01-medium text-neutral-600 hover:bg-neutral-400 active:bg-neutral-400"
+          >
+            취소
+          </Button>
+          <Button
+            variant="secondary"
+            size="medium"
+            isLoading={isLoading}
+            onClick={onConfirm}
+            className="h-12 w-0 min-w-0 flex-1 rounded-full border-0 bg-primary-500 text-body-01-medium text-neutral-00 hover:bg-primary-600 active:bg-primary-700"
+          >
+            탈퇴하기
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/web/src/features/my-page/index.ts
+++ b/apps/web/src/features/my-page/index.ts
@@ -1,4 +1,5 @@
 export { default as LogoutButton } from './components/LogoutButton';
+export { default as WithdrawAccountButton } from './components/WithdrawAccountButton';
 export { default as MyPageMenuItem } from './components/MyPageMenuItem';
 export { default as MyPageMenuSection } from './components/MyPageMenuSection';
 export { default as MyPageProfileSection } from './components/MyPageProfileSection';

--- a/apps/web/src/pages/my-page/MyPage.tsx
+++ b/apps/web/src/pages/my-page/MyPage.tsx
@@ -6,9 +6,10 @@ import {
   MyPageMenuSection,
   MyPageProfileSection,
   MyPageShortcutMenu,
+  WithdrawAccountButton,
   useGetMyAccount,
 } from '@/features/my-page';
-import { AccountRemoveIcon, ContactIcon, TermsIcon } from '@/shared/assets/icons';
+import { ContactIcon, TermsIcon } from '@/shared/assets/icons';
 import { ROUTE_PATHS } from '@/shared/constants/routePaths';
 import { StateView } from '@/shared/ui/state-view';
 
@@ -57,7 +58,7 @@ export default function MyPage() {
 
         <MyPageMenuSection className="mt-4">
           <LogoutButton />
-          <MyPageMenuItem icon={AccountRemoveIcon} label="회원탈퇴" />
+          <WithdrawAccountButton />
         </MyPageMenuSection>
       </section>
     </main>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #142

## ✅ 체크 사항

- [ ] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### 인증 콜백 상태 분기

- `loginCode` 수신 시 기존 토큰 교환을 진행합니다.
- `error=oauth_cancelled` 수신 시 로그인 화면으로 복귀합니다.
- `error=withdrawal_cancelled` 수신 시 인증 상태를 복원하고 마이페이지로 복귀합니다.
- `withdrawal=success` 수신 시 인증 정보와 쿼리 캐시를 정리하고 완료 안내 후 메인 화면으로 이동합니다.

### 오류 안내 문구 적용

- `error=account_withdrawn`
  - 탈퇴한 계정은 로그인할 수 없다는 안내를 표시합니다.
  - 계정 데이터가 탈퇴 다음 날 0시에 삭제되며, 삭제 이후 재가입할 수 있음을 안내합니다.
- `error=oauth_failed`
  - 소셜 로그인 실패 안내를 표시합니다.
- `error=withdrawal_failed`
  - 회원 탈퇴 실패 안내를 표시합니다.

### 📸 스크린샷

- 없음

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항
