### PR TITLE
✨ [Feat/#157] 문의하기 이메일 팝업 추가

### DIFF
--- a/apps/mobile/src/screens/home/HomeScreen.test.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.test.tsx
@@ -277,6 +277,16 @@ describe('<HomeScreen />', () => {
     expect(Linking.openURL).toHaveBeenCalledWith(googleMapsUrl);
   });
 
+  it('이메일 링크는 WebView에서 막고 기기의 메일 앱으로 전달한다', async () => {
+    process.env.EXPO_PUBLIC_WEB_URL = 'https://chapchap.example.com';
+    const { getByTestId } = await render(<HomeScreen />);
+    const shouldStartLoad = getByTestId('home-webview').props.onShouldStartLoadWithRequest;
+    const mailtoUrl = 'mailto:contact@chapchap.kr?subject=%5BChapChap%5D%20%EB%AC%B8%EC%9D%98';
+
+    expect(shouldStartLoad({ url: mailtoUrl })).toBe(false);
+    expect(Linking.openURL).toHaveBeenCalledWith(mailtoUrl);
+  });
+
   it('카카오톡 공유 스킴은 WebView에서 막고 카카오톡 앱으로 전달한다', async () => {
     process.env.EXPO_PUBLIC_WEB_URL = 'https://chapchap.example.com';
     const { getByTestId } = await render(<HomeScreen />);

--- a/apps/mobile/src/screens/home/HomeScreen.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.tsx
@@ -119,7 +119,7 @@ export default function HomeScreen() {
       return false;
     }
 
-    if (/^https?:\/\//i.test(url)) {
+    if (/^(?:https?:\/\/|mailto:)/i.test(url)) {
       void Linking.openURL(url).catch(() => {
         // TODO: 네이티브 공통 오류 안내 UI가 생기면 외부 링크 실행 실패를 사용자에게 알린다.
       });

--- a/apps/web/src/features/my-page/components/ContactButton.test.tsx
+++ b/apps/web/src/features/my-page/components/ContactButton.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useToast } from '@/shared/ui/toast';
+
+import ContactButton from './ContactButton';
+
+jest.mock('@/shared/ui/toast', () => ({ useToast: jest.fn() }));
+
+const mockShowToast = jest.fn();
+
+describe('ContactButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useToast).mockReturnValue({ showToast: mockShowToast, closeToast: jest.fn() });
+  });
+
+  it('문의 팝업에서 메일 앱 링크와 이메일 주소 복사를 제공한다', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    render(
+      <MemoryRouter>
+        <ContactButton />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: '문의하기' }));
+
+    expect(screen.getByRole('dialog', { name: '문의하기' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '메일 앱 열기' })).toHaveAttribute(
+      'href',
+      'mailto:contact@chapchap.kr?subject=%5BChapChap%5D%20%EB%AC%B8%EC%9D%98'
+    );
+
+    await user.click(screen.getByRole('button', { name: '주소 복사' }));
+
+    expect(writeText).toHaveBeenCalledWith('contact@chapchap.kr');
+    expect(mockShowToast).toHaveBeenCalledWith({
+      type: 'success',
+      message: '이메일 주소를 복사했어요.',
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('복사에 실패하면 오류를 안내하고 팝업을 유지한다', async () => {
+    const user = userEvent.setup();
+    jest.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('복사 실패'));
+    render(
+      <MemoryRouter>
+        <ContactButton />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: '문의하기' }));
+    await user.click(screen.getByRole('button', { name: '주소 복사' }));
+
+    expect(mockShowToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: '이메일 주소를 복사하지 못했어요.',
+    });
+    expect(screen.getByRole('dialog', { name: '문의하기' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/my-page/components/ContactButton.tsx
+++ b/apps/web/src/features/my-page/components/ContactButton.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import { ContactIcon } from '@/shared/assets/icons';
+import { useToast } from '@/shared/ui/toast';
+
+import ContactDialog, { CONTACT_EMAIL } from './ContactDialog';
+import MyPageMenuItem from './MyPageMenuItem';
+
+export default function ContactButton() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { showToast } = useToast();
+
+  const handleEmailCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(CONTACT_EMAIL);
+      showToast({ type: 'success', message: '이메일 주소를 복사했어요.' });
+      setIsDialogOpen(false);
+    } catch {
+      showToast({ type: 'error', message: '이메일 주소를 복사하지 못했어요.' });
+    }
+  };
+
+  return (
+    <>
+      <MyPageMenuItem icon={ContactIcon} label="문의하기" onClick={() => setIsDialogOpen(true)} />
+
+      {isDialogOpen && (
+        <ContactDialog
+          onClose={() => setIsDialogOpen(false)}
+          onCopy={() => void handleEmailCopy()}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/my-page/components/ContactDialog.tsx
+++ b/apps/web/src/features/my-page/components/ContactDialog.tsx
@@ -1,0 +1,77 @@
+import { useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { CloseIcon } from '@/shared/assets/icons';
+import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { useScrollLock } from '@/shared/hooks/useScrollLock';
+import { Button, LinkButton } from '@/shared/ui/button';
+
+export const CONTACT_EMAIL = 'contact@chapchap.kr';
+const CONTACT_MAILTO_URL = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent('[ChapChap] 문의')}`;
+
+type ContactDialogProps = {
+  onClose: () => void;
+  onCopy: () => void;
+};
+
+/** 이메일 앱 실행과 주소 복사를 제공하는 문의 다이얼로그입니다. */
+export default function ContactDialog({ onClose, onCopy }: ContactDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(dialogRef, {
+    initialFocusSelector: '[data-action="copy"]',
+    onEscape: onClose,
+  });
+  useScrollLock();
+
+  return createPortal(
+    <div className="mobile-frame fixed inset-0 z-dialog flex items-center justify-center bg-neutral-900/30 px-4">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="contact-title"
+        aria-describedby="contact-description"
+        className="relative w-full max-w-90.25 rounded-30 bg-neutral-00 px-4 pt-8 pb-4"
+      >
+        <button
+          type="button"
+          aria-label="문의 팝업 닫기"
+          className="absolute top-4 right-4 size-6 rounded-full p-1 text-neutral-500 outline-none hover:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-primary-300"
+          onClick={onClose}
+        >
+          <CloseIcon aria-hidden="true" className="size-full" />
+        </button>
+
+        <h2 id="contact-title" className="text-center text-title-01-bold text-neutral-700">
+          문의하기
+        </h2>
+        <p
+          id="contact-description"
+          className="mt-2 text-center text-body-01-regular text-neutral-500"
+        >
+          궁금한 점이나 불편한 점을 이메일로 보내주세요.
+        </p>
+        <p className="mt-5 rounded-12 bg-neutral-100 px-4 py-3 text-center text-body-01-medium text-neutral-700">
+          {CONTACT_EMAIL}
+        </p>
+
+        <div className="mt-6 flex gap-3">
+          <Button
+            data-action="copy"
+            variant="secondary"
+            size="medium"
+            onClick={onCopy}
+            className="h-12 w-0 min-w-0 flex-1 rounded-full"
+          >
+            주소 복사
+          </Button>
+          <LinkButton to={CONTACT_MAILTO_URL} size="medium" className="h-12 w-0 min-w-0 flex-1">
+            메일 앱 열기
+          </LinkButton>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/web/src/features/my-page/index.ts
+++ b/apps/web/src/features/my-page/index.ts
@@ -1,3 +1,4 @@
+export { default as ContactButton } from './components/ContactButton';
 export { default as LogoutButton } from './components/LogoutButton';
 export { default as WithdrawAccountButton } from './components/WithdrawAccountButton';
 export { default as MyPageMenuItem } from './components/MyPageMenuItem';

--- a/apps/web/src/pages/my-page/MyPage.tsx
+++ b/apps/web/src/pages/my-page/MyPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import {
+  ContactButton,
   LogoutButton,
   MyPageMenuItem,
   MyPageMenuSection,
@@ -9,7 +10,7 @@ import {
   WithdrawAccountButton,
   useGetMyAccount,
 } from '@/features/my-page';
-import { ContactIcon, TermsIcon } from '@/shared/assets/icons';
+import { TermsIcon } from '@/shared/assets/icons';
 import { ROUTE_PATHS } from '@/shared/constants/routePaths';
 import { StateView } from '@/shared/ui/state-view';
 
@@ -53,7 +54,7 @@ export default function MyPage() {
 
         <MyPageMenuSection>
           <MyPageMenuItem icon={TermsIcon} label="이용약관 및 개인정보처리방침" />
-          <MyPageMenuItem icon={ContactIcon} label="문의하기" />
+          <ContactButton />
         </MyPageMenuSection>
 
         <MyPageMenuSection className="mt-4">

--- a/packages/shared/src/toast/constants.ts
+++ b/packages/shared/src/toast/constants.ts
@@ -4,7 +4,7 @@ import type { ToastType } from './types';
 export const DEFAULT_TOAST_TYPE: ToastType = 'success';
 
 /** 별도 duration을 지정하지 않았을 때 Toast가 노출되는 시간입니다. */
-export const DEFAULT_TOAST_DURATION = 3000;
+export const DEFAULT_TOAST_DURATION = 1500;
 
 /** 한 화면에 동시에 유지할 수 있는 최대 Toast 개수입니다. */
 export const MAX_VISIBLE_TOASTS = 3;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #157

## ✅ 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그 및 에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션 확인

## 📝 작업 내용

### 문의하기 이메일 팝업

- 마이페이지의 `문의하기` 메뉴를 클릭 가능한 버튼으로 변경했습니다.
- 문의 이메일 주소를 확인할 수 있는 팝업을 추가했습니다.
- 이메일 주소 복사와 메일 앱 실행 기능을 제공합니다.
- 주소 복사 성공 및 실패 결과를 토스트로 안내합니다.
- 메일 제목에 `[ChapChap] 문의`가 자동으로 입력되도록 설정했습니다.

### 모바일 WebView 연동

- `mailto:` 링크를 네이티브 `Linking.openURL()`로 전달하도록 수정했습니다.
- 모바일 WebView에서 기기의 기본 메일 앱을 실행할 수 있도록 처리했습니다.
- 메일 앱 실행 경로에 대한 테스트를 추가했습니다.

### 토스트 노출 시간

- 웹과 모바일의 공통 토스트 기본 노출 시간을 3초에서 2초로 조정했습니다.

### 📸 스크린샷

- 없음

### 📦 추가한 라이브러리

- 없음

### 💬 리뷰 요구사항

- 